### PR TITLE
Refactored server/grpc to use the sidecar runtime structure

### DIFF
--- a/pkg/internal/server/grpc/auth.go
+++ b/pkg/internal/server/grpc/auth.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
+
+	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/internal/authn"
+	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/internal/authz"
+)
+
+func (s *Server) authenticateAndAuthorize(ctx context.Context, token string, namespace string) error {
+	// Authenticate request with security token and find the user identity
+	authenticated, userInfo, err := s.authenticateRequest(ctx, token)
+	if err != nil {
+		return status.Errorf(codes.Internal, msgInternalFailedToAuthenticateFmt, err)
+	}
+	if !authenticated {
+		return status.Error(codes.Unauthenticated, msgUnauthenticatedUser)
+	}
+
+	// Authorize user
+	authorizer := authz.NewSARAuthorizer(s.kubeClient())
+	decision, reason, err := authorizer.Authorize(ctx, userInfo, namespace)
+	if err != nil {
+		return status.Errorf(codes.Internal, mgsInternalFailedToAuthorizeFmt, err)
+	}
+	if decision != kauthorizer.DecisionAllow {
+		return status.Errorf(codes.PermissionDenied, msgPermissionDeniedFmt, reason)
+	}
+
+	return nil
+}
+
+func (s *Server) authenticateRequest(ctx context.Context, securityToken string) (bool, *authv1.UserInfo, error) {
+	// Find audienceToken from SnapshotMetadataService CR for the driver
+	audience, err := s.getAudienceForDriver(ctx)
+	if err != nil {
+		return false, nil, err
+	}
+
+	// Authenticate request with the security token
+	authenticator := authn.NewTokenAuthenticator(s.kubeClient())
+	return authenticator.Authenticate(ctx, securityToken, audience)
+}
+
+func (s *Server) getAudienceForDriver(ctx context.Context) (string, error) {
+	sms, err := s.cbtClient().CbtV1alpha1().SnapshotMetadataServices().Get(ctx, s.driverName(), metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get SnapshotMetadataService resource for driver %s: %v", s.driverName(), err)
+	}
+
+	return sms.Spec.Audience, nil
+}

--- a/pkg/internal/server/grpc/auth_test.go
+++ b/pkg/internal/server/grpc/auth_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+func TestAuthenticateAndAuthorize(t *testing.T) {
+	t.Run("crd-get-error", func(t *testing.T) {
+		th := newTestHarness()
+		s := th.ServerWithClientAPIs()
+		s.config.Runtime.DriverName += "foo"
+		assert.NotEqual(t, th.DriverName, s.driverName())
+
+		// direct call
+		retAudience, err := s.getAudienceForDriver(context.Background())
+		assert.Error(t, err)
+		assert.Empty(t, retAudience)
+
+		// fail via authenticateAndAuthorize
+		err = s.authenticateAndAuthorize(context.Background(), "some-token", "some-namespace")
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+		assert.ErrorContains(t, err, msgInternalFailedToAuthenticatePrefix)
+	})
+
+	t.Run("crd-get-success", func(t *testing.T) {
+		th := newTestHarness()
+		s := th.ServerWithClientAPIs()
+
+		retAudience, err := s.getAudienceForDriver(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, th.Audience, retAudience)
+	})
+
+	t.Run("authentication-error", func(t *testing.T) {
+		th := newTestHarness()
+		s := th.ServerWithClientAPIs()
+
+		// intercept the creation and fail
+		kubeClient := s.config.Runtime.KubeClient.(*fake.Clientset)
+		kubeClient.PrependReactor("create", "tokenreviews", func(action clientgotesting.Action) (handled bool, ret apiruntime.Object, err error) {
+			return true, nil, errors.New("create-tokenreview-error")
+		})
+
+		// direct call
+		authenticated, ui, err := s.authenticateRequest(context.Background(), th.SecurityToken+"foo")
+		assert.Error(t, err)
+		assert.False(t, authenticated)
+		assert.Nil(t, ui)
+
+		// fail via authenticateAndAuthorize
+		err = s.authenticateAndAuthorize(context.Background(), th.SecurityToken+"foo", "some-namespace")
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+		assert.ErrorContains(t, err, msgInternalFailedToAuthenticatePrefix)
+	})
+
+	t.Run("not-authenticated", func(t *testing.T) {
+		th := newTestHarness()
+		s := th.ServerWithClientAPIs()
+
+		// direct call
+		authenticated, ui, err := s.authenticateRequest(context.Background(), th.SecurityToken+"foo")
+		assert.NoError(t, err)
+		assert.False(t, authenticated)
+		assert.Nil(t, ui)
+
+		// fails via authenticateAndAuthorize
+		err = s.authenticateAndAuthorize(context.Background(), th.SecurityToken+"foo", "some-namespace")
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+		assert.ErrorContains(t, err, msgUnauthenticatedUser)
+	})
+
+	t.Run("authorization-error", func(t *testing.T) {
+		th := newTestHarness()
+		s := th.ServerWithClientAPIs()
+
+		// intercept the creation and fail
+		kubeClient := s.config.Runtime.KubeClient.(*fake.Clientset)
+		kubeClient.PrependReactor("create", "subjectaccessreviews", func(action clientgotesting.Action) (handled bool, ret apiruntime.Object, err error) {
+			return true, nil, errors.New("create-subjectaccessreviews-error")
+		})
+
+		err := s.authenticateAndAuthorize(context.Background(), th.SecurityToken, th.Namespace)
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+		assert.ErrorContains(t, err, mgsInternalFailedToAuthorizePrefix)
+	})
+
+	t.Run("not-authorized", func(t *testing.T) {
+		th := newTestHarness()
+		s := th.ServerWithClientAPIs()
+
+		err := s.authenticateAndAuthorize(context.Background(), th.SecurityToken, th.Namespace+"foo")
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		assert.ErrorContains(t, err, msgPermissionDeniedPrefix)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		th := newTestHarness()
+		s := th.ServerWithClientAPIs()
+
+		err := s.authenticateAndAuthorize(context.Background(), th.SecurityToken, th.Namespace)
+		assert.NoError(t, err)
+	})
+}

--- a/pkg/internal/server/grpc/common_test.go
+++ b/pkg/internal/server/grpc/common_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	authv1 "k8s.io/api/authentication/v1"
+	v1 "k8s.io/api/authorization/v1"
+	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+
+	smsv1alpha1 "github.com/kubernetes-csi/external-snapshot-metadata/client/apis/snapshotmetadataservice/v1alpha1"
+	fakecbt "github.com/kubernetes-csi/external-snapshot-metadata/client/clientset/versioned/fake"
+	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/api"
+	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/internal/runtime"
+)
+
+type testHarness struct {
+	SecurityToken string
+	DriverName    string
+	Audience      string
+	Namespace     string
+
+	grpcServer *grpc.Server
+	listener   *bufconn.Listener
+}
+
+func newTestHarness() *testHarness {
+	return &testHarness{
+		SecurityToken: "securityToken",
+		DriverName:    "driver",
+		Audience:      "audience",
+		Namespace:     "namespace",
+	}
+}
+
+func (th *testHarness) ServerWithClientAPIs() *Server {
+	s := &Server{
+		config: ServerConfig{Runtime: &runtime.Runtime{
+			CBTClient:  th.FakeCBTClient(),
+			KubeClient: th.FakeKubeClient(),
+			DriverName: th.DriverName,
+		}},
+	}
+
+	return s
+}
+
+func (th *testHarness) StartGRPCServer(t *testing.T) *Server {
+	buffer := 1024 * 1024
+
+	th.listener = bufconn.Listen(buffer)
+	th.grpcServer = grpc.NewServer()
+
+	s := th.ServerWithClientAPIs()
+	s.grpcServer = th.grpcServer
+	api.RegisterSnapshotMetadataServer(s.grpcServer, s)
+
+	go func() {
+		s.grpcServer.Serve(th.listener)
+	}()
+
+	return s
+}
+
+func (th *testHarness) StopGRPCServer(t *testing.T) {
+	err := th.listener.Close()
+	assert.NoError(t, err)
+
+	th.grpcServer.Stop()
+}
+
+func (th *testHarness) GRPCClient(t *testing.T) api.SnapshotMetadataClient {
+	conn, err := grpc.NewClient("passthrough://bufconn",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return th.listener.Dial()
+		}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	assert.NoError(t, err)
+
+	return api.NewSnapshotMetadataClient(conn)
+}
+
+func (th *testHarness) FakeKubeClient() *fake.Clientset {
+	kubeClient := fake.NewSimpleClientset()
+
+	kubeClient.PrependReactor("create", "tokenreviews", func(action clientgotesting.Action) (handled bool, ret apiruntime.Object, err error) {
+		ca := action.(clientgotesting.CreateAction)
+		trs := ca.GetObject().(*authv1.TokenReview)
+		trs.Status.Authenticated = false
+		if trs.Spec.Token == th.SecurityToken {
+			trs.Status.Authenticated = true
+			trs.Status.Audiences = []string{th.Audience, "other-" + th.Audience}
+		}
+		return true, trs, nil
+	})
+
+	kubeClient.PrependReactor("create", "subjectaccessreviews", func(action clientgotesting.Action) (handled bool, ret apiruntime.Object, err error) {
+		ca := action.(clientgotesting.CreateAction)
+		sar := ca.GetObject().(*v1.SubjectAccessReview)
+		if sar.Spec.ResourceAttributes != nil && sar.Spec.ResourceAttributes.Namespace == th.Namespace {
+			sar.Status.Allowed = true
+		} else {
+			sar.Status.Allowed = false
+			sar.Status.Reason = "namespace mismatch"
+		}
+		return true, sar, nil
+	})
+
+	return kubeClient
+}
+
+func (th *testHarness) FakeCBTClient() *fakecbt.Clientset {
+	cbtClient := fakecbt.NewSimpleClientset()
+	cbtClient.PrependReactor("get", "snapshotmetadataservices", func(action clientgotesting.Action) (handled bool, ret apiruntime.Object, err error) {
+		ga := action.(clientgotesting.GetAction)
+		if ga.GetName() != th.DriverName {
+			return false, nil, nil
+		}
+		sms := &smsv1alpha1.SnapshotMetadataService{
+			ObjectMeta: apimetav1.ObjectMeta{
+				Name: th.DriverName,
+			},
+			Spec: smsv1alpha1.SnapshotMetadataServiceSpec{
+				Audience: th.Audience,
+			},
+		}
+		return true, sms, nil
+	})
+
+	return cbtClient
+}
+
+// Support to test TLS routines utilizes test cert/key
+// data from crypto/tls/tls_test.go.
+type testTLSCertGenerator struct {
+	certFile string
+	keyFile  string
+}
+
+// GetTLSFiles returns the names of temporary cert and key files.
+// Use Cleanup() to release these files.
+func (tcg *testTLSCertGenerator) GetTLSFiles(t *testing.T) (string, string) {
+	tcg.certFile = tcg.writeTempFile(t, "cert", rsaCertPEM)
+	tcg.keyFile = tcg.writeTempFile(t, "key", rsaKeyPEM)
+
+	return tcg.certFile, tcg.keyFile
+}
+
+func (tcg *testTLSCertGenerator) writeTempFile(t *testing.T, pattern, content string) string {
+	f, err := os.CreateTemp("", pattern)
+	if err != nil {
+		tcg.cleanup(nil)
+	}
+	assert.NoError(t, err)
+
+	if _, err = f.Write([]byte(content)); err != nil {
+		tcg.cleanup(f)
+	}
+	assert.NoError(t, err)
+
+	if err = f.Close(); err != nil {
+		tcg.cleanup(f)
+	}
+	assert.NoError(t, err)
+
+	return f.Name()
+}
+
+func (tcg *testTLSCertGenerator) cleanup(f *os.File) {
+	if f != nil {
+		os.Remove(f.Name())
+	}
+
+	tcg.Cleanup()
+}
+
+func (tcg *testTLSCertGenerator) Cleanup() {
+	if tcg.certFile != "" {
+		os.Remove(tcg.certFile)
+		tcg.certFile = ""
+	}
+
+	if tcg.keyFile != "" {
+		os.Remove(tcg.keyFile)
+		tcg.keyFile = ""
+	}
+
+}
+
+// The following is copied from crypto/tls/tls_test.go
+var rsaCertPEM = `-----BEGIN CERTIFICATE-----
+MIIB0zCCAX2gAwIBAgIJAI/M7BYjwB+uMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
+aWRnaXRzIFB0eSBMdGQwHhcNMTIwOTEyMjE1MjAyWhcNMTUwOTEyMjE1MjAyWjBF
+MQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50
+ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANLJ
+hPHhITqQbPklG3ibCVxwGMRfp/v4XqhfdQHdcVfHap6NQ5Wok/4xIA+ui35/MmNa
+rtNuC+BdZ1tMuVCPFZcCAwEAAaNQME4wHQYDVR0OBBYEFJvKs8RfJaXTH08W+SGv
+zQyKn0H8MB8GA1UdIwQYMBaAFJvKs8RfJaXTH08W+SGvzQyKn0H8MAwGA1UdEwQF
+MAMBAf8wDQYJKoZIhvcNAQEFBQADQQBJlffJHybjDGxRMqaRmDhX0+6v02TUKZsW
+r5QuVbpQhH6u+0UgcW0jp9QwpxoPTLTWGXEWBBBurxFwiCBhkQ+V
+-----END CERTIFICATE-----
+`
+
+var rsaKeyPEM = testingKey(`-----BEGIN RSA TESTING KEY-----
+MIIBOwIBAAJBANLJhPHhITqQbPklG3ibCVxwGMRfp/v4XqhfdQHdcVfHap6NQ5Wo
+k/4xIA+ui35/MmNartNuC+BdZ1tMuVCPFZcCAwEAAQJAEJ2N+zsR0Xn8/Q6twa4G
+6OB1M1WO+k+ztnX/1SvNeWu8D6GImtupLTYgjZcHufykj09jiHmjHx8u8ZZB/o1N
+MQIhAPW+eyZo7ay3lMz1V01WVjNKK9QSn1MJlb06h/LuYv9FAiEA25WPedKgVyCW
+SmUwbPw8fnTcpqDWE3yTO3vKcebqMSsCIBF3UmVue8YU3jybC3NxuXq3wNm34R8T
+xVLHwDXh/6NJAiEAl2oHGGLz64BuAfjKrqwz7qMYr9HCLIe/YsoWq/olzScCIQDi
+D2lWusoe2/nEqfDVVWGWlyJ7yOmqaVm/iNUN9B2N2g==
+-----END RSA TESTING KEY-----
+`)
+
+func testingKey(s string) string { return strings.ReplaceAll(s, "TESTING KEY", "PRIVATE KEY") }

--- a/pkg/internal/server/grpc/snaphotmetadata_handlers.go
+++ b/pkg/internal/server/grpc/snaphotmetadata_handlers.go
@@ -17,26 +17,12 @@ limitations under the License.
 package grpc
 
 import (
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/api"
 )
 
-func (s *Server) registerService() {
-	api.RegisterSnapshotMetadataServer(s.grpcServer, s)
-}
-
 func (s *Server) GetMetadataAllocated(req *api.GetMetadataAllocatedRequest, stream api.SnapshotMetadata_GetMetadataAllocatedServer) error {
-	// validate request
-	if len(req.GetSecurityToken()) == 0 {
-		return status.Errorf(codes.InvalidArgument, "securityToken is missing")
-	}
-	if len(req.GetNamespace()) == 0 {
-		return status.Errorf(codes.InvalidArgument, "namespace parameter cannot be empty")
-	}
-	if len(req.GetSnapshotName()) == 0 {
-		return status.Errorf(codes.InvalidArgument, "snapshotName cannot be empty")
+	if err := ValidateGetMetadataAllocatedRequest(req); err != nil {
+		return err
 	}
 
 	ctx := stream.Context()
@@ -47,19 +33,10 @@ func (s *Server) GetMetadataAllocated(req *api.GetMetadataAllocatedRequest, stre
 	// TODO: Call CSI driver endpoint for changed block metadata
 	return nil
 }
+
 func (s *Server) GetMetadataDelta(req *api.GetMetadataDeltaRequest, stream api.SnapshotMetadata_GetMetadataDeltaServer) error {
-	// validate request
-	if len(req.GetSecurityToken()) == 0 {
-		return status.Errorf(codes.InvalidArgument, "securityToken is missing")
-	}
-	if len(req.GetNamespace()) == 0 {
-		return status.Errorf(codes.InvalidArgument, "namespace parameter cannot be empty")
-	}
-	if len(req.GetBaseSnapshotName()) == 0 {
-		return status.Errorf(codes.InvalidArgument, "baseSnapshotName cannot be empty")
-	}
-	if len(req.GetTargetSnapshotName()) == 0 {
-		return status.Errorf(codes.InvalidArgument, "targetSnapshotName cannot be empty")
+	if err := ValidateGetMetadataDeltaRequest(req); err != nil {
+		return err
 	}
 
 	ctx := stream.Context()

--- a/pkg/internal/server/grpc/snapshotmetadata_handlers_test.go
+++ b/pkg/internal/server/grpc/snapshotmetadata_handlers_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/api"
+)
+
+func TestGetMetadataDeltaViaGRPCClient(t *testing.T) {
+	ctx := context.Background()
+
+	th := newTestHarness()
+	th.StartGRPCServer(t)
+	defer th.StopGRPCServer(t)
+
+	client := th.GRPCClient(t)
+
+	for _, tc := range []struct {
+		name              string
+		req               *api.GetMetadataDeltaRequest
+		expectStreamError bool
+		expStatusCode     codes.Code
+		expStatusMsg      string
+	}{
+		{
+			name:              "invalid arguments",
+			req:               &api.GetMetadataDeltaRequest{},
+			expectStreamError: true,
+			expStatusCode:     codes.InvalidArgument,
+			expStatusMsg:      msgInvalidArgumentSecurityTokenMissing,
+		},
+		{
+			name: "invalid token",
+			req: &api.GetMetadataDeltaRequest{
+				SecurityToken:      th.SecurityToken + "FOO",
+				Namespace:          th.Namespace,
+				BaseSnapshotName:   "snap-1",
+				TargetSnapshotName: "snap-2",
+			},
+			expectStreamError: true,
+			expStatusCode:     codes.Unauthenticated,
+			expStatusMsg:      msgUnauthenticatedUser,
+		},
+		{
+			name: "success",
+			req: &api.GetMetadataDeltaRequest{
+				SecurityToken:      th.SecurityToken,
+				Namespace:          th.Namespace,
+				BaseSnapshotName:   "snap-1",
+				TargetSnapshotName: "snap-2",
+			},
+			expectStreamError: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stream, err := client.GetMetadataDelta(ctx, tc.req)
+
+			assert.NoError(t, err)
+
+			_, errStream := stream.Recv()
+
+			if tc.expectStreamError {
+				assert.NotNil(t, errStream)
+				st, ok := status.FromError(errStream)
+				assert.True(t, ok)
+				assert.Equal(t, tc.expStatusCode, st.Code())
+				assert.Equal(t, tc.expStatusMsg, st.Message())
+			} else if errStream != nil {
+				assert.ErrorIs(t, errStream, io.EOF)
+			}
+		})
+	}
+}
+
+func TestGetMetadataAllocatedViaGRPCClient(t *testing.T) {
+	ctx := context.Background()
+
+	th := newTestHarness()
+	th.StartGRPCServer(t)
+	defer th.StopGRPCServer(t)
+
+	client := th.GRPCClient(t)
+
+	for _, tc := range []struct {
+		name              string
+		req               *api.GetMetadataAllocatedRequest
+		expectStreamError bool
+		expStatusCode     codes.Code
+		expStatusMsg      string
+	}{
+		{
+			name:              "invalid arguments",
+			req:               &api.GetMetadataAllocatedRequest{},
+			expectStreamError: true,
+			expStatusCode:     codes.InvalidArgument,
+			expStatusMsg:      msgInvalidArgumentSecurityTokenMissing,
+		},
+		{
+			name: "invalid token",
+			req: &api.GetMetadataAllocatedRequest{
+				SecurityToken: th.SecurityToken + "FOO",
+				Namespace:     th.Namespace,
+				SnapshotName:  "snap-1",
+			},
+			expectStreamError: true,
+			expStatusCode:     codes.Unauthenticated,
+			expStatusMsg:      msgUnauthenticatedUser,
+		},
+		{
+			name: "success",
+			req: &api.GetMetadataAllocatedRequest{
+				SecurityToken: th.SecurityToken,
+				Namespace:     th.Namespace,
+				SnapshotName:  "snap-1",
+			},
+			expectStreamError: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stream, err := client.GetMetadataAllocated(ctx, tc.req)
+
+			assert.NoError(t, err)
+
+			_, errStream := stream.Recv()
+
+			if tc.expectStreamError {
+				assert.NotNil(t, errStream)
+				st, ok := status.FromError(errStream)
+				assert.True(t, ok)
+				assert.Equal(t, tc.expStatusCode, st.Code())
+				assert.Equal(t, tc.expStatusMsg, st.Message())
+			} else if errStream != nil {
+				assert.ErrorIs(t, errStream, io.EOF)
+			}
+		})
+	}
+}

--- a/pkg/internal/server/grpc/status_msgs.go
+++ b/pkg/internal/server/grpc/status_msgs.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+const (
+	mgsInternalFailedToAuthorizePrefix    = "failed to authorize the user"
+	mgsInternalFailedToAuthorizeFmt       = mgsInternalFailedToAuthorizePrefix + ": %v"
+	msgInternalFailedToAuthenticatePrefix = "failed to authenticate user"
+	msgInternalFailedToAuthenticateFmt    = msgInternalFailedToAuthenticatePrefix + ": %v"
+
+	msgInvalidArgumentBaseSnapshotNameMissing   = "baseSnapshotName cannot be empty"
+	msgInvalidArgumentNamespaceMissing          = "namespace parameter cannot be empty"
+	msgInvalidArgumentSecurityTokenMissing      = "securityToken is missing"
+	msgInvalidArgumentSnaphotNameMissing        = "snapshotName cannot be empty"
+	msgInvalidArgumentTargetSnapshotNameMissing = "targetSnapshotName cannot be empty"
+
+	msgPermissionDeniedPrefix = "user does not have permissions to perform the operation"
+	msgPermissionDeniedFmt    = msgPermissionDeniedPrefix + ": %s"
+
+	msgUnauthenticatedUser = "unauthenticated user"
+)

--- a/pkg/internal/server/grpc/validators.go
+++ b/pkg/internal/server/grpc/validators.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/api"
+)
+
+func ValidateGetMetadataAllocatedRequest(req *api.GetMetadataAllocatedRequest) error {
+	if len(req.GetSecurityToken()) == 0 {
+		return status.Errorf(codes.InvalidArgument, msgInvalidArgumentSecurityTokenMissing)
+	}
+
+	if len(req.GetNamespace()) == 0 {
+		return status.Errorf(codes.InvalidArgument, msgInvalidArgumentNamespaceMissing)
+	}
+
+	if len(req.GetSnapshotName()) == 0 {
+		return status.Errorf(codes.InvalidArgument, msgInvalidArgumentSnaphotNameMissing)
+	}
+
+	return nil
+}
+
+func ValidateGetMetadataDeltaRequest(req *api.GetMetadataDeltaRequest) error {
+	// validate request
+	if len(req.GetSecurityToken()) == 0 {
+		return status.Errorf(codes.InvalidArgument, msgInvalidArgumentSecurityTokenMissing)
+	}
+	if len(req.GetNamespace()) == 0 {
+		return status.Errorf(codes.InvalidArgument, msgInvalidArgumentNamespaceMissing)
+	}
+	if len(req.GetBaseSnapshotName()) == 0 {
+		return status.Errorf(codes.InvalidArgument, msgInvalidArgumentBaseSnapshotNameMissing)
+	}
+	if len(req.GetTargetSnapshotName()) == 0 {
+		return status.Errorf(codes.InvalidArgument, msgInvalidArgumentTargetSnapshotNameMissing)
+	}
+
+	return nil
+}

--- a/pkg/internal/server/grpc/validators_test.go
+++ b/pkg/internal/server/grpc/validators_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/api"
+)
+
+func TestValidateGetMetadataAllocatedRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		req           *api.GetMetadataAllocatedRequest
+		isValid       bool
+		expStatusCode codes.Code
+		expStatusMsg  string
+	}{
+		{
+			name:          "nil",
+			req:           nil,
+			expStatusCode: codes.InvalidArgument,
+			expStatusMsg:  msgInvalidArgumentSecurityTokenMissing,
+		},
+		{
+			name:          "empty arguments",
+			req:           &api.GetMetadataAllocatedRequest{},
+			expStatusCode: codes.InvalidArgument,
+			expStatusMsg:  msgInvalidArgumentSecurityTokenMissing,
+		},
+		{
+			name: "missing security token",
+			req: &api.GetMetadataAllocatedRequest{
+				Namespace:    "test-ns",
+				SnapshotName: "snap-1",
+			},
+			expStatusCode: codes.InvalidArgument,
+			expStatusMsg:  msgInvalidArgumentSecurityTokenMissing,
+		},
+		{
+			name: "namespace missing",
+			req: &api.GetMetadataAllocatedRequest{
+				SecurityToken: "token",
+				SnapshotName:  "snap-1",
+			},
+			expStatusCode: codes.InvalidArgument,
+			expStatusMsg:  msgInvalidArgumentNamespaceMissing,
+		},
+		{
+			name: "snapshotName missing",
+			req: &api.GetMetadataAllocatedRequest{
+				SecurityToken: "token",
+				Namespace:     "test-ns",
+			},
+			expStatusCode: codes.InvalidArgument,
+			expStatusMsg:  msgInvalidArgumentSnaphotNameMissing,
+		},
+		{
+			name: "valid",
+			req: &api.GetMetadataAllocatedRequest{
+				SecurityToken: "token",
+				Namespace:     "test-ns",
+				SnapshotName:  "snap-1",
+			},
+			isValid: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGetMetadataAllocatedRequest(tc.req)
+			if !tc.isValid {
+				assert.Error(t, err)
+				st, ok := status.FromError(err)
+				assert.True(t, ok)
+				assert.Equal(t, tc.expStatusCode, st.Code())
+				assert.Equal(t, tc.expStatusMsg, st.Message())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateGetMetadataDeltaRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		req           *api.GetMetadataDeltaRequest
+		isValid       bool
+		expStatusCode codes.Code
+		expStatusMsg  string
+	}{
+		{
+			name:          "nil",
+			req:           nil,
+			expStatusCode: codes.InvalidArgument,
+			expStatusMsg:  msgInvalidArgumentSecurityTokenMissing,
+		},
+		{
+			name:          "empty arguments",
+			req:           &api.GetMetadataDeltaRequest{},
+			expStatusCode: codes.InvalidArgument,
+			expStatusMsg:  msgInvalidArgumentSecurityTokenMissing,
+		},
+		{
+			name: "missing security token",
+			req: &api.GetMetadataDeltaRequest{
+				Namespace:          "test-ns",
+				BaseSnapshotName:   "snap-1",
+				TargetSnapshotName: "snap-2",
+			},
+			expStatusCode: codes.InvalidArgument,
+			expStatusMsg:  msgInvalidArgumentSecurityTokenMissing,
+		},
+		{
+			name: "namespace missing",
+			req: &api.GetMetadataDeltaRequest{
+				SecurityToken:      "token",
+				BaseSnapshotName:   "snap-1",
+				TargetSnapshotName: "snap-2",
+			},
+			expStatusCode: codes.InvalidArgument,
+			expStatusMsg:  msgInvalidArgumentNamespaceMissing,
+		},
+		{
+			name: "base SnapshotName missing",
+			req: &api.GetMetadataDeltaRequest{
+				SecurityToken:      "token",
+				Namespace:          "test-ns",
+				TargetSnapshotName: "snap-2",
+			},
+			expStatusCode: codes.InvalidArgument,
+			expStatusMsg:  msgInvalidArgumentBaseSnapshotNameMissing,
+		},
+		{
+			name: "target SnapshotName missing",
+			req: &api.GetMetadataDeltaRequest{
+				SecurityToken:    "token",
+				Namespace:        "test-ns",
+				BaseSnapshotName: "snap-1",
+			},
+			expStatusCode: codes.InvalidArgument,
+			expStatusMsg:  msgInvalidArgumentTargetSnapshotNameMissing,
+		},
+		{
+			name: "valid",
+			req: &api.GetMetadataDeltaRequest{
+				SecurityToken:      "token",
+				Namespace:          "test-ns",
+				BaseSnapshotName:   "snap-1",
+				TargetSnapshotName: "snap-2",
+			},
+			isValid: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGetMetadataDeltaRequest(tc.req)
+			if !tc.isValid {
+				assert.Error(t, err)
+				st, ok := status.FromError(err)
+				assert.True(t, ok)
+				assert.Equal(t, tc.expStatusCode, st.Code())
+				assert.Equal(t, tc.expStatusMsg, st.Message())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refactored slightly to separate the start/stop and the authorization and authentication
logic from the handlers.

Rewrote existing unit tests and added additional tests in server/grpc to improve code coverage.

Addresses https://github.com/kubernetes-csi/external-snapshot-metadata/issues/15.