### PR TITLE
Added the gRPC health service.

### DIFF
--- a/pkg/internal/server/grpc/health.go
+++ b/pkg/internal/server/grpc/health.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	klog "k8s.io/klog/v2"
+)
+
+func newHealthServer() *health.Server {
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+
+	return healthServer
+}
+
+// isReady indicates whether the sidecar can serve metadata.
+func (s *Server) isReady() bool {
+	resp, err := s.healthServer.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	if err == nil && resp.Status == healthpb.HealthCheckResponse_SERVING {
+		return true
+	}
+
+	return false
+}
+
+// setReady should be called when the sidecar is ready to serve metadata.
+func (s *Server) setReady() {
+	klog.Info("Setting status to SERVING")
+	s.healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+}
+
+func (s *Server) setNotReady() {
+	klog.Info("Setting status to NOT_SERVING")
+	s.healthServer.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+}
+
+// shuttingDown transitions to the NotReady state and removes the ability to change state.
+func (s *Server) shuttingDown() {
+	klog.Info("Shutting down: setting status to NOT_SERVING")
+	s.healthServer.Shutdown()
+}

--- a/pkg/internal/server/grpc/health_test.go
+++ b/pkg/internal/server/grpc/health_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestHealthService(t *testing.T) {
+	t.Run("state-transitions", func(t *testing.T) {
+		th := newTestHarness()
+		server := th.ServerWithClientAPIs()
+
+		assert.False(t, server.isReady())
+
+		server.setReady()
+		assert.True(t, server.isReady())
+
+		server.setNotReady()
+		assert.False(t, server.isReady())
+
+		server.setReady()
+		assert.True(t, server.isReady())
+
+		server.shuttingDown()
+		assert.False(t, server.isReady())
+
+		server.setReady()
+		assert.False(t, server.isReady()) // cannot change state once shutdown.
+	})
+
+	t.Run("client-health-checks", func(t *testing.T) {
+		th := newTestHarness()
+		server := th.StartGRPCServer(t)
+		defer th.StopGRPCServer(t)
+
+		client := th.GRPCHealthClient(t)
+		ctx := context.Background()
+
+		resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, healthpb.HealthCheckResponse_NOT_SERVING, resp.Status)
+
+		server.CSIDriverIsReady()
+
+		resp, err = client.Check(ctx, &healthpb.HealthCheckRequest{})
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.Status)
+
+		server.setNotReady()
+
+		resp, err = client.Check(ctx, &healthpb.HealthCheckRequest{})
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, healthpb.HealthCheckResponse_NOT_SERVING, resp.Status)
+
+		server.setReady()
+
+		resp, err = client.Check(ctx, &healthpb.HealthCheckRequest{})
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.Status)
+
+		server.shuttingDown()
+
+		resp, err = client.Check(ctx, &healthpb.HealthCheckRequest{})
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, healthpb.HealthCheckResponse_NOT_SERVING, resp.Status)
+	})
+}

--- a/pkg/internal/server/grpc/status_msgs.go
+++ b/pkg/internal/server/grpc/status_msgs.go
@@ -32,4 +32,6 @@ const (
 	msgPermissionDeniedFmt    = msgPermissionDeniedPrefix + ": %s"
 
 	msgUnauthenticatedUser = "unauthenticated user"
+
+	msgUnavailableCSIDriverNotReady = "the CSI driver is not yet ready"
 )


### PR DESCRIPTION
The availability of the CSI driver is tracked by the health service and is used to determine whether to serve snapshot metadata requests.

Fixes:
- https://github.com/kubernetes-csi/external-snapshot-metadata/issues/9
- https://github.com/kubernetes-csi/external-snapshot-metadata/issues/12.