### PR TITLE
Extended the runtime test harness

### DIFF
--- a/pkg/internal/runtime/runtime_test.go
+++ b/pkg/internal/runtime/runtime_test.go
@@ -17,29 +17,16 @@ limitations under the License.
 package runtime
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"net"
-	"os"
-	"path"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
-	"github.com/kubernetes-csi/csi-lib-utils/connection"
-	"github.com/kubernetes-csi/csi-lib-utils/metrics"
-	"github.com/kubernetes-csi/csi-test/v5/driver"
 	"github.com/stretchr/testify/assert"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
-
-	utiltesting "k8s.io/client-go/util/testing"
 )
 
 func TestNew(t *testing.T) {
@@ -74,9 +61,9 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("kubeconfig-error", func(t *testing.T) {
-		th := newTestHarness()
+		th := NewTestHarness()
 
-		args := th.Runtime().Args // use harness runtime for the args
+		args := th.RuntimeArgs()
 		args.CSIAddress = "1.2.3.4"
 		args.Kubeconfig = "/invalid/file/path"
 
@@ -88,11 +75,12 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("cluster-config-error", func(t *testing.T) {
-		th := newTestHarness()
+		th := NewTestHarness()
 
 		t.Setenv("KUBERNETES_SERVICE_HOST", "")
 
-		err := th.Runtime().kubeConnect("", 0, 0)
+		rt := Runtime{Args: th.RuntimeArgs()}
+		err := rt.kubeConnect("", 0, 0)
 
 		assert.Error(t, err, "expected failure in InClusterConfig")
 		assert.Contains(t, err.Error(), "error in cluster config")
@@ -100,10 +88,10 @@ func TestNew(t *testing.T) {
 
 	t.Run("csi-driver-connection-failure", func(t *testing.T) {
 		// indirect invocation of csiConnect via New.
-		th := newTestHarness().WithFakeKubeConfig(t)
+		th := NewTestHarness().WithFakeKubeConfig(t)
 		defer th.RemoveFakeKubeConfig(t)
 
-		expArgs := th.Runtime().Args // use harness runtime for the args
+		expArgs := th.RuntimeArgs()
 		assert.NotEmpty(t, expArgs.Kubeconfig)
 
 		expArgs.CSIAddress = "0.0.0.0" // force failure
@@ -116,12 +104,15 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("get-driver-name-error", func(t *testing.T) {
-		th := newTestHarness().WithFakeKubeConfig(t).WithFakeGRPCServer(t)
+		th := NewTestHarness().WithFakeKubeConfig(t).WithFakeCSIDriver(t, nil)
 		defer th.RemoveFakeKubeConfig(t)
-		defer th.TerminateGRPCServer(t)
+		defer th.TerminateFakeCSIDriver(t)
 
-		expArgs := th.Runtime().Args // use the harness args
+		expArgs := th.RuntimeArgs()
 		assert.NotEmpty(t, expArgs.Kubeconfig)
+
+		// remove the fake driver name
+		th.FakeCSIDriverName = ""
 
 		rt, err := New(expArgs)
 
@@ -131,14 +122,14 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		th := newTestHarness().WithFakeKubeConfig(t).WithFakeGRPCServer(t)
+		th := NewTestHarness().WithFakeKubeConfig(t).WithFakeCSIDriver(t, nil)
 		defer th.RemoveFakeKubeConfig(t)
-		defer th.TerminateGRPCServer(t)
+		defer th.TerminateFakeCSIDriver(t)
 
 		expDriverName := "csi-driver-name"
-		th.FakeGRPCDriverName = expDriverName
+		th.FakeCSIDriverName = expDriverName
 
-		expArgs := th.Runtime().Args // use the harness args
+		expArgs := th.RuntimeArgs()
 		assert.NotEmpty(t, expArgs.Kubeconfig)
 
 		rt, err := New(expArgs)
@@ -159,12 +150,12 @@ func TestNew(t *testing.T) {
 
 func TestWaitTillCSIDriverIsValidated(t *testing.T) {
 	t.Run("probe-error", func(t *testing.T) {
-		th := newTestHarness().WithMockCSIDriver(t)
+		th := NewTestHarness().WithMockCSIDriver(t)
 		defer th.TerminateMockCSIDriver()
 
 		th.MockCSIIdentityServer.EXPECT().Probe(gomock.Any(), gomock.Any()).Return(nil, errors.New("fake-error")).AnyTimes()
 
-		rt := th.Runtime()
+		rt := th.RuntimeForMockCSIDriver(t)
 		assert.NotNil(t, rt.CSIConn)
 
 		err := rt.WaitTillCSIDriverIsValidated()
@@ -174,7 +165,7 @@ func TestWaitTillCSIDriverIsValidated(t *testing.T) {
 	})
 
 	t.Run("get-capabilities-error", func(t *testing.T) {
-		th := newTestHarness().WithMockCSIDriver(t)
+		th := NewTestHarness().WithMockCSIDriver(t)
 		defer th.TerminateMockCSIDriver()
 
 		rspProbe := &csi.ProbeResponse{
@@ -184,7 +175,7 @@ func TestWaitTillCSIDriverIsValidated(t *testing.T) {
 
 		th.MockCSIIdentityServer.EXPECT().GetPluginCapabilities(gomock.Any(), gomock.Any()).Return(nil, errors.New("fake-error"))
 
-		rt := th.Runtime()
+		rt := th.RuntimeForMockCSIDriver(t)
 		assert.NotNil(t, rt.CSIConn)
 
 		err := rt.WaitTillCSIDriverIsValidated()
@@ -194,7 +185,7 @@ func TestWaitTillCSIDriverIsValidated(t *testing.T) {
 	})
 
 	t.Run("no-snapshot-metadata-service", func(t *testing.T) {
-		th := newTestHarness().WithMockCSIDriver(t)
+		th := NewTestHarness().WithMockCSIDriver(t)
 		defer th.TerminateMockCSIDriver()
 
 		rspProbe := &csi.ProbeResponse{
@@ -205,7 +196,7 @@ func TestWaitTillCSIDriverIsValidated(t *testing.T) {
 		rspGetPluginCapabilities := &csi.GetPluginCapabilitiesResponse{}
 		th.MockCSIIdentityServer.EXPECT().GetPluginCapabilities(gomock.Any(), gomock.Any()).Return(rspGetPluginCapabilities, nil)
 
-		rt := th.Runtime()
+		rt := th.RuntimeForMockCSIDriver(t)
 		assert.NotNil(t, rt.CSIConn)
 		assert.NotEmpty(t, rt.CSITimeout)
 
@@ -216,7 +207,7 @@ func TestWaitTillCSIDriverIsValidated(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		th := newTestHarness().WithMockCSIDriver(t)
+		th := NewTestHarness().WithMockCSIDriver(t)
 		defer th.TerminateMockCSIDriver()
 
 		rspProbe := &csi.ProbeResponse{
@@ -237,7 +228,7 @@ func TestWaitTillCSIDriverIsValidated(t *testing.T) {
 		}
 		th.MockCSIIdentityServer.EXPECT().GetPluginCapabilities(gomock.Any(), gomock.Any()).Return(rspGetPluginCapabilities, nil)
 
-		rt := th.Runtime()
+		rt := th.RuntimeForMockCSIDriver(t)
 		assert.NotNil(t, rt.CSIConn)
 		assert.NotEmpty(t, rt.CSITimeout)
 
@@ -245,176 +236,4 @@ func TestWaitTillCSIDriverIsValidated(t *testing.T) {
 
 		assert.NoError(t, err, "CSICheckDriver")
 	})
-}
-
-type testHarness struct {
-	CSIDriverConn         *grpc.ClientConn
-	MockController        *gomock.Controller
-	MockCSIDriver         *driver.MockCSIDriver
-	MockCSIIdentityServer *driver.MockIdentityServer
-
-	fakeGRPCServerDir  string
-	fakeGRPCServer     *grpc.Server
-	fakeServerWg       sync.WaitGroup
-	FakeGRPCServerAddr string
-	FakeGRPCDriverName string // fake CSI driver name
-
-	FakeKubeConfigFile *os.File
-
-	// for the mock IdentityServer
-	*csi.UnimplementedIdentityServer
-}
-
-func newTestHarness() *testHarness {
-	return &testHarness{}
-}
-
-func (th *testHarness) Runtime() *Runtime {
-	rt := &Runtime{
-		Args: Args{
-			CSIAddress:   th.FakeGRPCServerAddr, // needs WithFakeGRPCServer
-			CSITimeout:   20 * time.Millisecond, // UT timeout
-			KubeAPIBurst: 99,                    // arbitrary
-			KubeAPIQPS:   3.142,                 // arbitrary
-			GRPCPort:     8000,                  // arbitrary
-			TLSCertFile:  "/certfile",           // arbitrary
-			TLSKeyFile:   "/keyfile",            //arbitrary
-		},
-		CSIConn: th.CSIDriverConn, // needs WithMockCSIDriver
-	}
-	if th.FakeKubeConfigFile != nil { // needs WithFakeKubeConfig
-		rt.Kubeconfig = th.FakeKubeConfigFile.Name()
-	}
-	return rt
-}
-
-// WithFakeKubeConfig uses the pattern in client-go/tools/client/cmd/client_config_test.go.
-func (th *testHarness) WithFakeKubeConfig(t *testing.T) *testHarness {
-	tmpfile, err := os.CreateTemp("", "kubeconfig")
-	assert.NoError(t, err, "os.CreateTemp")
-
-	th.FakeKubeConfigFile = tmpfile
-
-	content := `
-apiVersion: v1
-clusters:
-- cluster:
-    server: https://localhost:8080
-  name: foo-cluster
-contexts:
-- context:
-    cluster: foo-cluster
-    user: foo-user
-    namespace: bar
-  name: foo-context
-current-context: foo-context
-kind: Config
-users:
-- name: foo-user
-  user:
-    token: sha256~iHnHE6AwK3udV9kIJddQpA9W_MxfOZg4BraIO4ywwDY
-`
-	err = os.WriteFile(tmpfile.Name(), []byte(content), 0666)
-	if err != nil {
-		th.RemoveFakeKubeConfig(t)
-		assert.NoError(t, err, "os.WriteFile")
-	}
-
-	return th
-}
-
-func (th *testHarness) RemoveFakeKubeConfig(t *testing.T) {
-	utiltesting.CloseAndRemove(t, th.FakeKubeConfigFile)
-}
-
-func (th *testHarness) WithMockCSIDriver(t *testing.T) *testHarness {
-	// Start the mock server
-	mockController := gomock.NewController(t)
-	identityServer := driver.NewMockIdentityServer(mockController)
-	metricsManager := metrics.NewCSIMetricsManagerForSidecar("" /* driverName */)
-	drv := driver.NewMockCSIDriver(&driver.MockCSIDriverServers{
-		Identity: identityServer,
-		// TODO: add expected mock services
-	})
-	err := drv.Start()
-	assert.NoError(t, err, "drv.Start")
-
-	// Create a client connection to it
-	addr := drv.Address()
-	csiConn, err := connection.Connect(context.Background(), addr, metricsManager)
-	if err != nil {
-		t.Fatal("Connect", err)
-	}
-
-	th.CSIDriverConn = csiConn
-	th.MockController = mockController
-	th.MockCSIDriver = drv
-	th.MockCSIIdentityServer = identityServer
-
-	return th
-}
-
-func (th *testHarness) TerminateMockCSIDriver() {
-	th.MockController.Finish()
-	th.MockCSIDriver.Stop()
-	th.CSIDriverConn.Close()
-}
-
-// WithFakeGRPCServer uses the pattern in csi-lib-utils/connection/connection_test.go.
-func (th *testHarness) WithFakeGRPCServer(t *testing.T, opt ...grpc.ServerOption) *testHarness {
-	dir, err := os.MkdirTemp("", "csi")
-	assert.NoError(t, err, "os.MkdirTemp")
-
-	th.fakeGRPCServerDir = dir
-
-	th.FakeGRPCServerAddr = path.Join(dir, "server.sock")
-	listener, err := net.Listen("unix", th.FakeGRPCServerAddr)
-	if err != nil {
-		th.TerminateGRPCServer(t)
-		assert.NoError(t, err, "net.Listen")
-	}
-
-	th.fakeGRPCServer = grpc.NewServer()
-	csi.RegisterIdentityServer(th.fakeGRPCServer, th) // the harness implements an identity server
-
-	th.fakeServerWg.Add(1)
-	go func() {
-		defer th.fakeServerWg.Done()
-		if err := th.fakeGRPCServer.Serve(listener); err != nil {
-			assert.NoError(t, err, "fakeServer.Serve")
-		}
-	}()
-
-	return th
-}
-
-func (th *testHarness) TerminateGRPCServer(t *testing.T) {
-	if th.fakeGRPCServer != nil {
-		th.fakeGRPCServer.Stop()
-		th.fakeServerWg.Wait()
-	}
-	if th.fakeGRPCServerDir != "" {
-		os.RemoveAll(th.fakeGRPCServerDir)
-	}
-}
-
-// The test harness fakes an identity server for the fake gRPC service
-
-func (th *testHarness) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
-	if th.FakeGRPCDriverName != "" {
-		rspGetPluginInfo := &csi.GetPluginInfoResponse{
-			Name: th.FakeGRPCDriverName,
-		}
-		return rspGetPluginInfo, nil
-	}
-
-	return nil, status.Error(codes.Unimplemented, "Unimplemented")
-}
-
-func (th *testHarness) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "Unimplemented")
-}
-
-func (th *testHarness) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "Unimplemented")
 }

--- a/pkg/internal/runtime/test_harness.go
+++ b/pkg/internal/runtime/test_harness.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+// This file exposes a test harness for the runtime.
+
+import (
+	"context"
+	"net"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/golang/mock/gomock"
+	"github.com/kubernetes-csi/csi-lib-utils/connection"
+	"github.com/kubernetes-csi/csi-lib-utils/metrics"
+	"github.com/kubernetes-csi/csi-test/v5/driver"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	utiltesting "k8s.io/client-go/util/testing"
+)
+
+// TestHarness provides a Runtime that can either work with a fake CSI driver
+// based on the csi-test framework, or a mock CSI driver with the CSI Identity and
+// CSI SnapshotMetadata servers.
+//
+//  1. Mock CSI driver usage example
+//     th := NewTestHarness().WithMockCSIDriver(t)
+//     defer th.TerminateMockCSIDriver()
+//     th.MockCSIIdentityServer.EXPECT().GetDriverName(gomock.Any(), gomock.Any()).Return("driver",nil)
+//     rt := th.RuntimeForMockCSIDriver(t)
+//     name, err := csirpc.GetDriverName(ctx, rt.CSIConn) // sample GRPC client call
+//
+//  2. Fake CSI driver usage example
+//     sms := &fakeSnapshotMetadataServer{} // optional
+//     th := NewTestHarness().WithFakeKubeConfig(t).WithFakeCSIDriver(t, sms)
+//     defer th.RemoveFakeKubeConfig(t)
+//     defer th.TerminateFakeCSIDriver(t)
+//     rt := th.RuntimeForFakeCSIDriver(t)
+//     name, err := csirpc.GetDriverName(ctx, rt.CSIConn) // sample GRPC client call
+//
+//  3. The runtime args can point to real TLS cert and key files instead of non-existent paths.
+//     th := NewTestHarness().WithTestTLSFiles(t).With...
+//     defer th.RemoveFakeTLSFiles(t)
+//     rta := th.RuntimeArgs()
+//     cert, err := tls.LoadX509KeyPair(rta.TLSCertFile, rta.TLSKeyFile)
+type TestHarness struct {
+	MockController                *gomock.Controller
+	MockCSIDriver                 *driver.MockCSIDriver
+	MockCSIIdentityServer         *driver.MockIdentityServer
+	MockCSISnapshotMetadataServer *driver.MockSnapshotMetadataServer
+
+	FakeCSIDriver *driver.CSIDriver
+
+	// Identity server responses
+	FakeCSIDriverName                 string
+	FakeProbeResponse                 *csi.ProbeResponse
+	FakeGetPluginCapabilitiesResponse *csi.GetPluginCapabilitiesResponse
+
+	// internal
+	fakeCSIDriverAddr  string
+	fakeKubeConfigFile *os.File
+	fakeGRPCServerDir  string
+	mockCSIDriverConn  *grpc.ClientConn
+	tlsCertFile        string
+	tlsKeyFile         string
+	tlsGenerator       *testTLSCertGenerator
+
+	// for the mock/fake servers
+	*csi.UnimplementedIdentityServer
+}
+
+// NewTestHarness returns a new TestHarness.
+func NewTestHarness() *TestHarness {
+	return &TestHarness{
+		tlsCertFile: "/certfile", // will be replaced with real files
+		tlsKeyFile:  "/keyfile",  // by WithTestTLSFiles()
+	}
+}
+
+func (th *TestHarness) RuntimeArgs() Args {
+	var kubeConfigFile string
+	if th.fakeKubeConfigFile != nil {
+		kubeConfigFile = th.fakeKubeConfigFile.Name()
+	}
+
+	return Args{
+		CSIAddress:   th.fakeCSIDriverAddr,
+		CSITimeout:   20 * time.Millisecond, // UT timeout
+		KubeAPIBurst: 99,                    // arbitrary
+		KubeAPIQPS:   3.142,                 // arbitrary
+		Kubeconfig:   kubeConfigFile,
+		GRPCPort:     8000, // arbitrary
+		TLSCertFile:  th.tlsCertFile,
+		TLSKeyFile:   th.tlsKeyFile,
+	}
+}
+
+func (th *TestHarness) RuntimeForMockCSIDriver(t *testing.T) *Runtime {
+	assert.NotNil(t, th.mockCSIDriverConn, "needs WithMockCSIDriver")
+	rt := &Runtime{
+		Args:    th.RuntimeArgs(),
+		CSIConn: th.mockCSIDriverConn,
+	}
+	return rt
+}
+
+func (th *TestHarness) RuntimeForFakeCSIDriver(t *testing.T) *Runtime {
+	assert.NotNil(t, th.fakeKubeConfigFile, "needs WithFakeKubeConfig")
+	assert.NotEmpty(t, th.fakeCSIDriverAddr, "needs WithFakeCSIDriver")
+	rt, err := New(th.RuntimeArgs())
+	assert.NoError(t, err)
+	return rt
+}
+
+// WithFakeKubeConfig creates a kubeconfig file that is needed to communicate
+// with the fake CSI driver.
+func (th *TestHarness) WithFakeKubeConfig(t *testing.T) *TestHarness {
+	// Use the pattern in client-go/tools/client/cmd/client_config_test.go.
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
+	assert.NoError(t, err, "os.CreateTemp")
+
+	th.fakeKubeConfigFile = tmpfile
+
+	content := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8080
+  name: foo-cluster
+contexts:
+- context:
+    cluster: foo-cluster
+    user: foo-user
+    namespace: bar
+  name: foo-context
+current-context: foo-context
+kind: Config
+users:
+- name: foo-user
+  user:
+    token: sha256~iHnHE6AwK3udV9kIJddQpA9W_MxfOZg4BraIO4ywwDY
+`
+	err = os.WriteFile(tmpfile.Name(), []byte(content), 0666)
+	if err != nil {
+		th.RemoveFakeKubeConfig(t)
+		assert.NoError(t, err, "os.WriteFile")
+	}
+
+	return th
+}
+
+func (th *TestHarness) RemoveFakeKubeConfig(t *testing.T) {
+	utiltesting.CloseAndRemove(t, th.fakeKubeConfigFile)
+}
+
+// WithTestTLSFiles will provide temporary but valid TLS files.
+func (th *TestHarness) WithTestTLSFiles(t *testing.T) *TestHarness {
+	th.tlsGenerator = &testTLSCertGenerator{}
+	th.tlsCertFile, th.tlsKeyFile = th.tlsGenerator.GetTLSFiles(t)
+
+	return th
+}
+
+func (th *TestHarness) RemoveTestTLSFiles(_ *testing.T) {
+	th.tlsGenerator.Cleanup()
+}
+
+func (th *TestHarness) WithMockCSIDriver(t *testing.T) *TestHarness {
+	// Start the mock server
+	mockController := gomock.NewController(t)
+	identityServer := driver.NewMockIdentityServer(mockController)
+	snapshotMetadataServer := driver.NewMockSnapshotMetadataServer(mockController)
+	metricsManager := metrics.NewCSIMetricsManagerForSidecar("" /* driverName */)
+	drv := driver.NewMockCSIDriver(&driver.MockCSIDriverServers{
+		Identity:         identityServer,
+		SnapshotMetadata: snapshotMetadataServer,
+	})
+	err := drv.Start()
+	assert.NoError(t, err, "drv.Start")
+
+	// Create a client connection to it
+	addr := drv.Address()
+	csiConn, err := connection.Connect(context.Background(), addr, metricsManager)
+	if err != nil {
+		t.Fatal("Connect", err)
+	}
+
+	th.mockCSIDriverConn = csiConn
+	th.MockController = mockController
+	th.MockCSIDriver = drv
+	th.MockCSIIdentityServer = identityServer
+	th.MockCSISnapshotMetadataServer = snapshotMetadataServer
+
+	return th
+}
+
+func (th *TestHarness) TerminateMockCSIDriver() {
+	th.MockController.Finish()
+	th.MockCSIDriver.Stop()
+	th.mockCSIDriverConn.Close()
+}
+
+// WithFakeCSIDriver launches a fake CSIDriver, optionally with a provided SnapshotMetadataServer.
+// It initializes the FakeCSIDriverName field.
+// If a SnapshotMetadataServer is provided then it initializes the FakeGetPluginCapabilitiesResponse
+// field to set the capability for the service.
+func (th *TestHarness) WithFakeCSIDriver(t *testing.T, sms csi.SnapshotMetadataServer) *TestHarness {
+	// Use the pattern in csi-lib-utils/connection/connection_test.go.
+	dir, err := os.MkdirTemp("", "csi")
+	assert.NoError(t, err, "os.MkdirTemp")
+
+	th.fakeGRPCServerDir = dir
+
+	th.fakeCSIDriverAddr = path.Join(dir, "server.sock")
+	listener, err := net.Listen("unix", th.fakeCSIDriverAddr)
+	if err != nil {
+		th.TerminateFakeCSIDriver(t)
+		assert.NoError(t, err, "net.Listen")
+	}
+
+	// the test harness implements the  IdentityServer and the invoker can provide a SnapshotMetadataServer.
+	servers := &driver.CSIDriverServers{
+		Identity:         th,
+		SnapshotMetadata: sms,
+	}
+
+	csiDriver := driver.NewCSIDriver(servers)
+	err = csiDriver.Start(listener)
+	assert.NoError(t, err)
+
+	th.FakeCSIDriver = csiDriver
+	th.FakeCSIDriverName = "fake-csi-driver"
+	if sms != nil {
+		// ensure that the service gets advertised.
+		th.FakeGetPluginCapabilitiesResponse = &csi.GetPluginCapabilitiesResponse{
+			Capabilities: []*csi.PluginCapability{
+				{
+					Type: &csi.PluginCapability_Service_{
+						Service: &csi.PluginCapability_Service{
+							Type: csi.PluginCapability_Service_SNAPSHOT_METADATA_SERVICE,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return th
+}
+
+func (th *TestHarness) TerminateFakeCSIDriver(t *testing.T) {
+	if th.FakeCSIDriver != nil {
+		th.FakeCSIDriver.Stop()
+	}
+	if th.fakeGRPCServerDir != "" {
+		os.RemoveAll(th.fakeGRPCServerDir)
+	}
+}
+
+func (th *TestHarness) AssertErrorStatus(t *testing.T, err error, c codes.Code, msgRegex string) {
+	t.Helper()
+	st, ok := status.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, c, st.Code())
+	assert.Regexp(t, msgRegex, st.Message())
+}
+
+// The test harness fakes an identity server for the fake gRPC service
+
+func (th *TestHarness) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
+	if th.FakeCSIDriverName != "" {
+		rspGetPluginInfo := &csi.GetPluginInfoResponse{
+			Name: th.FakeCSIDriverName,
+		}
+		return rspGetPluginInfo, nil
+	}
+
+	return nil, status.Error(codes.Unimplemented, "GetPluginInfo is not implemented")
+}
+
+func (th *TestHarness) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+	if th.FakeProbeResponse != nil {
+		return th.FakeProbeResponse, nil
+	}
+	return nil, status.Error(codes.Unimplemented, "Probe is not implemented")
+}
+
+func (th *TestHarness) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+	if th.FakeGetPluginCapabilitiesResponse != nil {
+		return th.FakeGetPluginCapabilitiesResponse, nil
+	}
+	return nil, status.Error(codes.Unimplemented, "GetPluginCapabilities is not implemented")
+}
+
+// Support to test TLS routines utilizes test cert/key data from crypto/tls/tls_test.go.
+type testTLSCertGenerator struct {
+	certFile string
+	keyFile  string
+}
+
+// GetTLSFiles returns the names of temporary cert and key files.
+// Use Cleanup() to release these files.
+func (tcg *testTLSCertGenerator) GetTLSFiles(t *testing.T) (string, string) {
+	tcg.certFile = tcg.writeTempFile(t, "cert", rsaCertPEM)
+	tcg.keyFile = tcg.writeTempFile(t, "key", rsaKeyPEM)
+
+	return tcg.certFile, tcg.keyFile
+}
+
+func (tcg *testTLSCertGenerator) writeTempFile(t *testing.T, pattern, content string) string {
+	f, err := os.CreateTemp("", pattern)
+	if err != nil {
+		tcg.cleanup(nil)
+	}
+	assert.NoError(t, err)
+
+	if _, err = f.Write([]byte(content)); err != nil {
+		tcg.cleanup(f)
+	}
+	assert.NoError(t, err)
+
+	if err = f.Close(); err != nil {
+		tcg.cleanup(f)
+	}
+	assert.NoError(t, err)
+
+	return f.Name()
+}
+
+func (tcg *testTLSCertGenerator) cleanup(f *os.File) {
+	if f != nil {
+		os.Remove(f.Name())
+	}
+
+	tcg.Cleanup()
+}
+
+func (tcg *testTLSCertGenerator) Cleanup() {
+	if tcg.certFile != "" {
+		os.Remove(tcg.certFile)
+		tcg.certFile = ""
+	}
+
+	if tcg.keyFile != "" {
+		os.Remove(tcg.keyFile)
+		tcg.keyFile = ""
+	}
+
+}
+
+// The following is copied from crypto/tls/tls_test.go
+var rsaCertPEM = `-----BEGIN CERTIFICATE-----
+MIIB0zCCAX2gAwIBAgIJAI/M7BYjwB+uMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
+aWRnaXRzIFB0eSBMdGQwHhcNMTIwOTEyMjE1MjAyWhcNMTUwOTEyMjE1MjAyWjBF
+MQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50
+ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANLJ
+hPHhITqQbPklG3ibCVxwGMRfp/v4XqhfdQHdcVfHap6NQ5Wok/4xIA+ui35/MmNa
+rtNuC+BdZ1tMuVCPFZcCAwEAAaNQME4wHQYDVR0OBBYEFJvKs8RfJaXTH08W+SGv
+zQyKn0H8MB8GA1UdIwQYMBaAFJvKs8RfJaXTH08W+SGvzQyKn0H8MAwGA1UdEwQF
+MAMBAf8wDQYJKoZIhvcNAQEFBQADQQBJlffJHybjDGxRMqaRmDhX0+6v02TUKZsW
+r5QuVbpQhH6u+0UgcW0jp9QwpxoPTLTWGXEWBBBurxFwiCBhkQ+V
+-----END CERTIFICATE-----
+`
+
+var rsaKeyPEM = testingKey(`-----BEGIN RSA TESTING KEY-----
+MIIBOwIBAAJBANLJhPHhITqQbPklG3ibCVxwGMRfp/v4XqhfdQHdcVfHap6NQ5Wo
+k/4xIA+ui35/MmNartNuC+BdZ1tMuVCPFZcCAwEAAQJAEJ2N+zsR0Xn8/Q6twa4G
+6OB1M1WO+k+ztnX/1SvNeWu8D6GImtupLTYgjZcHufykj09jiHmjHx8u8ZZB/o1N
+MQIhAPW+eyZo7ay3lMz1V01WVjNKK9QSn1MJlb06h/LuYv9FAiEA25WPedKgVyCW
+SmUwbPw8fnTcpqDWE3yTO3vKcebqMSsCIBF3UmVue8YU3jybC3NxuXq3wNm34R8T
+xVLHwDXh/6NJAiEAl2oHGGLz64BuAfjKrqwz7qMYr9HCLIe/YsoWq/olzScCIQDi
+D2lWusoe2/nEqfDVVWGWlyJ7yOmqaVm/iNUN9B2N2g==
+-----END RSA TESTING KEY-----
+`)
+
+func testingKey(s string) string { return strings.ReplaceAll(s, "TESTING KEY", "PRIVATE KEY") }

--- a/pkg/internal/runtime/test_harness_test.go
+++ b/pkg/internal/runtime/test_harness_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	csirpc "github.com/kubernetes-csi/csi-lib-utils/rpc"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestRuntimeTestHarness(t *testing.T) {
+	t.Run("tls-files", func(t *testing.T) {
+		th := NewTestHarness().WithTestTLSFiles(t)
+		defer th.RemoveTestTLSFiles(t)
+
+		rta := th.RuntimeArgs()
+
+		cert, err := tls.LoadX509KeyPair(rta.TLSCertFile, rta.TLSKeyFile)
+		assert.NoError(t, err)
+		assert.NotNil(t, cert)
+	})
+
+	t.Run("fake-identity-server", func(t *testing.T) {
+		th := NewTestHarness().WithFakeKubeConfig(t).WithFakeCSIDriver(t, nil)
+		defer th.RemoveFakeKubeConfig(t)
+		defer th.TerminateFakeCSIDriver(t)
+
+		ctx := context.Background()
+
+		rt := th.RuntimeForFakeCSIDriver(t)
+		assert.NotNil(t, rt.CSIConn)
+
+		driverName, err := csirpc.GetDriverName(ctx, rt.CSIConn)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, driverName)
+
+		th.FakeCSIDriverName = ""
+		driverName, err = csirpc.GetDriverName(ctx, rt.CSIConn)
+		assert.Error(t, err)
+		assert.Empty(t, driverName)
+		th.AssertErrorStatus(t, err, codes.Unimplemented, "GetPluginInfo is not implemented")
+
+		ready, err := csirpc.Probe(ctx, rt.CSIConn)
+		assert.Error(t, err)
+		assert.False(t, ready)
+		th.AssertErrorStatus(t, err, codes.Unimplemented, "Probe is not implemented")
+
+		th.FakeProbeResponse = &csi.ProbeResponse{Ready: wrapperspb.Bool(true)}
+		ready, err = csirpc.Probe(ctx, rt.CSIConn)
+		assert.NoError(t, err)
+		assert.True(t, ready)
+
+		pc, err := csirpc.GetPluginCapabilities(ctx, rt.CSIConn)
+		assert.Error(t, err)
+		assert.Nil(t, pc)
+		th.AssertErrorStatus(t, err, codes.Unimplemented, "GetPluginCapabilities is not implemented")
+
+		th.FakeGetPluginCapabilitiesResponse = &csi.GetPluginCapabilitiesResponse{
+			Capabilities: []*csi.PluginCapability{
+				{
+					Type: &csi.PluginCapability_Service_{
+						Service: &csi.PluginCapability_Service{
+							Type: csi.PluginCapability_Service_SNAPSHOT_METADATA_SERVICE,
+						},
+					},
+				},
+			},
+		}
+		pc, err = csirpc.GetPluginCapabilities(ctx, rt.CSIConn)
+		assert.NoError(t, err)
+		assert.NotNil(t, pc)
+		_, found := pc[csi.PluginCapability_Service_SNAPSHOT_METADATA_SERVICE]
+		assert.True(t, found)
+	})
+
+	t.Run("fake-snapshot-metadata-server", func(t *testing.T) {
+		sms := &testSnapshotMetadataServer{}
+		th := NewTestHarness().WithFakeKubeConfig(t).WithFakeCSIDriver(t, sms)
+		defer th.RemoveFakeKubeConfig(t)
+		defer th.TerminateFakeCSIDriver(t)
+
+		ctx := context.Background()
+
+		rt := th.RuntimeForFakeCSIDriver(t)
+		assert.NotNil(t, rt.CSIConn)
+
+		// capability set automatically when the SnapshotMetadataServer is specified.
+		pc, err := csirpc.GetPluginCapabilities(ctx, rt.CSIConn)
+		assert.NoError(t, err)
+		assert.NotNil(t, pc)
+		_, found := pc[csi.PluginCapability_Service_SNAPSHOT_METADATA_SERVICE]
+		assert.True(t, found)
+
+		client := csi.NewSnapshotMetadataClient(rt.CSIConn)
+
+		gmaStream, err := client.GetMetadataAllocated(ctx, &csi.GetMetadataAllocatedRequest{})
+		assert.NoError(t, err)
+		assert.NotNil(t, gmaStream)
+		_, err = gmaStream.Recv()
+		assert.Error(t, err)
+		th.AssertErrorStatus(t, err, codes.Unimplemented, "GetMetadataAllocated is not implemented")
+
+		gmdStream, err := client.GetMetadataDelta(ctx, &csi.GetMetadataDeltaRequest{})
+		assert.NoError(t, err)
+		assert.NotNil(t, gmdStream)
+		_, err = gmdStream.Recv()
+		assert.Error(t, err)
+		th.AssertErrorStatus(t, err, codes.Unimplemented, "GetMetadataDelta is not implemented")
+	})
+}
+
+type testSnapshotMetadataServer struct {
+	*csi.UnimplementedSnapshotMetadataServer
+}
+
+func (s *testSnapshotMetadataServer) GetMetadataAllocated(*csi.GetMetadataAllocatedRequest, csi.SnapshotMetadata_GetMetadataAllocatedServer) error {
+	return status.Error(codes.Unimplemented, "GetMetadataAllocated is not implemented")
+}
+
+func (s *testSnapshotMetadataServer) GetMetadataDelta(*csi.GetMetadataDeltaRequest, csi.SnapshotMetadata_GetMetadataDeltaServer) error {
+	return status.Error(codes.Unimplemented, "GetMetadataDelta is not implemented")
+}

--- a/pkg/internal/server/grpc/server_test.go
+++ b/pkg/internal/server/grpc/server_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package grpc
 
 import (
-	"crypto/tls"
 	"syscall"
 	"testing"
 	"time"
@@ -43,23 +42,14 @@ func TestNewServer(t *testing.T) {
 		},
 	}
 
-	t.Run("sanity-tls-generator", func(t *testing.T) {
-		tcg := &testTLSCertGenerator{}
-		defer tcg.Cleanup()
-
-		cert, err := tls.LoadX509KeyPair(tcg.GetTLSFiles(t))
-		assert.NoError(t, err)
-		assert.NotNil(t, cert)
-	})
-
 	t.Run("tls-load-error", func(t *testing.T) {
-		tcg := &testTLSCertGenerator{}
-		defer tcg.Cleanup()
+		th := runtime.NewTestHarness().WithTestTLSFiles(t)
+		defer th.RemoveTestTLSFiles(t)
+		rta := th.RuntimeArgs()
 
-		cf, kf := tcg.GetTLSFiles(t)
 		rt := *validConfig.Runtime // copy
-		rt.TLSCertFile = cf
-		rt.TLSKeyFile = kf + "foo" // invalid path
+		rt.TLSCertFile = rta.TLSCertFile
+		rt.TLSKeyFile = rta.TLSKeyFile + "foo" // invalid path
 
 		server, err := NewServer(ServerConfig{Runtime: &rt})
 		assert.Error(t, err)
@@ -67,13 +57,13 @@ func TestNewServer(t *testing.T) {
 	})
 
 	t.Run("listen-error", func(t *testing.T) {
-		tcg := &testTLSCertGenerator{}
-		defer tcg.Cleanup()
+		th := runtime.NewTestHarness().WithTestTLSFiles(t)
+		defer th.RemoveTestTLSFiles(t)
+		rta := th.RuntimeArgs()
 
-		cf, kf := tcg.GetTLSFiles(t)
 		rt := *validConfig.Runtime // copy
-		rt.TLSCertFile = cf
-		rt.TLSKeyFile = kf
+		rt.TLSCertFile = rta.TLSCertFile
+		rt.TLSKeyFile = rta.TLSKeyFile
 		rt.GRPCPort = -1 // invalid port
 
 		s, err := NewServer(ServerConfig{Runtime: &rt})
@@ -89,13 +79,13 @@ func TestNewServer(t *testing.T) {
 	})
 
 	t.Run("start-stop", func(t *testing.T) {
-		tcg := &testTLSCertGenerator{}
-		defer tcg.Cleanup()
+		th := runtime.NewTestHarness().WithTestTLSFiles(t)
+		defer th.RemoveTestTLSFiles(t)
+		rta := th.RuntimeArgs()
 
-		cf, kf := tcg.GetTLSFiles(t)
 		rt := *validConfig.Runtime // copy
-		rt.TLSCertFile = cf
-		rt.TLSKeyFile = kf
+		rt.TLSCertFile = rta.TLSCertFile
+		rt.TLSKeyFile = rta.TLSKeyFile
 
 		s, err := NewServer(ServerConfig{Runtime: &rt})
 		assert.NoError(t, err)


### PR DESCRIPTION
- Uses the `csi-test` infrastructure
- Supports a SnapshotMetadataService
- Exposed for use in any package that can use Runtime

Fixes:
- https://github.com/kubernetes-csi/external-snapshot-metadata/issues/22