### PR TITLE
Add deployment manifests to setup sidecar server

### DIFF
--- a/cmd/csi-snapshot-metadata/Dockerfile
+++ b/cmd/csi-snapshot-metadata/Dockerfile
@@ -1,8 +1,13 @@
+FROM alpine AS builder
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.13
+ADD https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 /bin/grpc_health_probe
+RUN chmod +x /bin/grpc_health_probe
+
 FROM gcr.io/distroless/static:latest
 LABEL maintainers="Kubernetes Authors"
 LABEL description="CSI External Snapshot Metadata Sidecar"
 ARG binary=./bin/csi-snapshot-metadata
-
+COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 COPY ${binary} csi-snapshot-metadata
 ENTRYPOINT ["/csi-snapshot-metadata"]
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,58 @@
+# Deployment guide
+
+## Prerequisites:
+
+Please ensure that your environment meets the following minimum requirements to use the Changed Block Tracking (CBT) feature:
+
+- Kubernetes 1.20 or higher
+- CSI provisioner with Volume Snapshot and SnapshotMetadata support.
+
+
+## Installation
+
+This directory contains the following components:
+
+**1. Common components**
+
+  This includes the necessary Roles, ClusterRoles, and Custom Resource Definitions (CRDs) that must be installed on your Kubernetes cluster independent of the CSI driver prior to deploying any CSI driver that utilizes the external-snapshot-metadata sidecar.
+
+**2. CSI Driver Example**
+
+  The `examples/csi-driver` directory contains sample manifests for deploying the external-snapshot-metadata sidecar with a CSI driver. You can use this example as a reference when installing a CSI driver with snapshot metadata support in your cluster.
+
+**3. Backup Application Example**
+
+The `examples/backup-app` directory provides sample manifests for Role-Based Access Control (RBAC) resources and a sample backup application. This example demonstrates how to set up a backup application that communicates with the snapshot-metadata service to utilize the Changed Block Tracking (CBT) feature.
+
+### Installation Steps
+
+Before installing the snapshot-metadata service, you must create specific Roles, ClusterRoles, and CRDs that are required for the service to function within your Kubernetes clusters.
+These components are independent of any CSI driver you intend to install.
+
+1. Create the ClusterRole for external-snapshot-metadata service.
+
+   Grant the necessary permissions to the snapshot-metadata service by creating the required ClusterRole:
+   
+   ```bash
+   $ kubectl create -f snapshot-metadata-cluster-role.yaml
+   ```
+
+2. Create the ClusterRole for snapshot-metadata client.
+
+   Grant the necessary permissions to the snapshot-metadata client by creating the required ClusterRole:
+   
+   ```bash
+   $ kubectl create -f snapshot-metadata-client-cluster-role.yaml
+   ```
+
+3. Create CRD
+
+   Register the SnapshotMetadataService resource by creating the necessary CRD:
+
+   ```bash
+   $ kubectl create -f cbt.storage.k8s.io_snapshotmetadataservices.yaml
+   ```
+
+### Next Steps
+
+Refer to the `examples/csi-driver` and `examples/backup-app` directories to deploy the snapshot-metadata service and the backup application.

--- a/deploy/cbt.storage.k8s.io_snapshotmetadataservices.yaml
+++ b/deploy/cbt.storage.k8s.io_snapshotmetadataservices.yaml
@@ -1,0 +1,1 @@
+../client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml

--- a/deploy/example/backup-app/README.md
+++ b/deploy/example/backup-app/README.md
@@ -1,0 +1,31 @@
+# Authorizing a Backup Application
+
+This document provides steps to authorize a backup application to interact with the snapshot-metadata service and utilize the Changed Block Tracking (CBT) feature. You can use this example as a reference when deploying the backup application with the required permissions to use the CBT feature.
+
+## Prerequisites:
+
+- Installed ClusterRoles and CRDs: Follow the instructions in this [guide](../../README.md) to ensure these components are installed.
+
+## Installation
+
+In this example, we will create the Kubernetes RBAC configuration for a backup application so that it can communicate with the snapshot-metadata service to retrieve CBT metadata for the given CSI snapshots.
+
+**Steps to deploy the sample backup application**
+
+1. Create a namespace
+
+   ```bash
+   $ kubectl create namespace backup-app-namespace
+   ```
+
+2. Create a ServiceAccount for the backup application
+
+   ```bash
+   $ kubectl create -f service-account.yaml
+   ```
+
+3. Create a ClusterRoleBinidng to authorize the backp application's ServiceAccount
+
+   ```bash
+   $ kubectl create -f cluster-role-binding.yaml
+   ```

--- a/deploy/example/backup-app/cluster-role-binding.yaml
+++ b/deploy/example/backup-app/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backup-app-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-snapshot-metadata-client
+subjects:
+- kind: ServiceAccount
+  name: backup-app-service-account
+  namespace: backup-app-namespace

--- a/deploy/example/backup-app/service-account.yaml
+++ b/deploy/example/backup-app/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backup-app-service-account
+  namespace: backup-app-namespace

--- a/deploy/example/csi-driver/README.md
+++ b/deploy/example/csi-driver/README.md
@@ -1,0 +1,96 @@
+# Example snapshot-metadata Service with CSI Driver
+
+This document illustrates how to install a CSI driver with the external-snapshot-metadata sidecar. You can use this example as a reference when installing a CSI driver with Changed Block Metadata (CBT) support in your cluster.
+
+## Prerequisites:
+
+Ensure that you have installed the necessary ClusterRoles and CRDs as explained in this [guide](../../README.md).
+
+
+## Installation
+
+In this example, we will deploy the snapshot-metadata service alongside a dummy CSI driver. While this example uses a dummy CSI driver, the steps may vary depending on the specific CSI driver you are using. Use the appropriate steps to deploy the CSI driver in your environment.
+
+**Steps to deploy snapshot-metadata with a dummy CSI driver:**
+
+1. Create a namespace
+
+   ```bash
+   $ kubectl create namespace csi-driver
+   ```
+   If you prefer to use different namespace, update the `namespace` fields in `csi-driver-with-snapshot-metadata-sidecar.yaml`.
+
+2. Provision TLS Certs
+
+   Generate self-signed certificates using following commands
+
+   ```bash
+   NAMESPACE="csi-driver"
+
+   # 1. Create extension file
+   echo "subjectAltName=DNS:.csi-driver,DNS:csi-dummyplugin.csi-driver,DNS:csi-dummyplugin.default,IP:0.0.0.0" > server-ext.cnf 
+
+   # 2. Generate CA's private key and self-signed certificate
+   openssl req -x509 -newkey rsa:4096 -days 365 -nodes -keyout ca-key.pem -out ca-cert.pem -subj "/CN=csi-dummyplugin.${NAMESPACE}"
+
+   openssl x509 -in ca-cert.pem -noout -text
+   
+   # 2. Generate web server's private key and certificate signing request (CSR)
+   openssl req -newkey rsa:4096 -nodes -keyout server-key.pem -out server-req.pem -subj "/CN=csi-dummyplugin.${NAMESPACE}"
+   
+   # 3. Use CA's private key to sign web server's CSR and get back the signed certificate
+   openssl x509 -req -in server-req.pem -days 60 -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem -extfile server-ext.cnf
+   
+   openssl x509 -in server-cert.pem -noout -text
+   ```
+
+3. Create a TLS secret 
+
+   ```bash
+   $ kubectl create secret tls csi-dummyplugin-certs --namespace=csi-driver --cert=server-cert.pem --key=server-key.pem 
+   ```
+
+4. Create `SnapshotMetadataService` resource
+
+   The name of the `SnapshotMetadataService` resource must match the name of the CSI driver for which you want to enable the CBT feature. In this example, we will create a `SnapshotMetadataService` for the `dummy.csi.k8s.io` CSI driver.
+
+   Create a file named `snapshotmetadataservice.yaml` with the following content:
+
+   ```yaml
+   apiVersion: cbt.storage.k8s.io/v1alpha1
+   kind: SnapshotMetadataService
+   metadata:
+     name: dummy.csi.k8s.io
+   spec:
+     address: csi-dummyplugin.csi-driver:6443
+     caCert: GENERATED_CA_CERT
+     audience: 005e2583-91a3-4850-bd47-4bf32990fd00
+   ```
+
+   Encode the CA Cert:
+
+   ```bash
+   $ base64 -i ca-cert.pem
+   ```
+
+   Copy the output and replace `GENERATED_CA_CERT` in the `SnapshotMetadataService` CR.
+   Update `spec.address` and `spec.audience` if required.
+
+   Create `SnapshotMetadataService` resource using the command below:
+
+   ```bash
+   $ kubectl create -f snapshotmetadataservice.yaml
+   ```
+
+5. Create ServiceAccount and ClusterRoleBinding for snapshot-metadata service
+
+   ```bash
+   $ kubectl create -f csi-driver-service-account.yaml
+   $ kubectl create -f csi-driver-cluster-role-binding.yaml
+   ```
+
+6. Deploy the CSI driver with snapshot-metadata sidecar service
+
+   ```bash
+   $ kubectl create -f csi-driver-with-snapshot-metadata-sidecar.yaml --namespace csi-driver
+   ```

--- a/deploy/example/csi-driver/csi-driver-cluster-role-binding.yaml
+++ b/deploy/example/csi-driver/csi-driver-cluster-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-dummyplugin-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-snapshot-metadata-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: csi-dummyplugin
+  # Replace if want to install in other namespace
+  namespace: csi-driver

--- a/deploy/example/csi-driver/csi-driver-service.yaml
+++ b/deploy/example/csi-driver/csi-driver-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: csi-dummyplugin
+  namespace: csi-driver
+  labels:
+    app.kubernetes.io/name: csi-dummyplugin
+spec:
+  ports:
+  - name: cbt
+    port: 6443
+    protocol: TCP
+    targetPort: 50051
+  selector:
+    app.kubernetes.io/name: csi-dummyplugin

--- a/deploy/example/csi-driver/csi-driver-with-snapshot-metadata-sidecar.yaml
+++ b/deploy/example/csi-driver/csi-driver-with-snapshot-metadata-sidecar.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-dummyplugin
+  namespace: csi-driver
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: csi-dummyplugin
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: csi-dummyplugin
+    spec:
+      serviceAccountName: csi-dummyplugin
+      containers:
+      # TODO: replace with hostpath driver plugin once SNAPSHOT_METADATA service is available
+      # Currently, it points to the Mock implementation of CSI driver https://github.com/PrasadG193/sample-csi-cbt-service
+      - name: csi-dummyplugin
+        image: prasadg193/sample-csi-cbt-service:latest
+        args:
+        - "--endpoint=unix://csi/csi.sock"
+        env:
+        - name: "DRIVER_NAME"
+          value: "dummy.csi.k8s.io"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - name: csi-snapshot-metadata
+        # TODO: Replace with build image once CI process is set
+        image: prasadg193/csi-snapshot-metadata:latest
+        command:
+        args:
+        - "-csi-address=unix:///csi/csi.sock"
+        - "-tls-cert=/tmp/certificates/tls.crt"
+        - "-tls-key=/tmp/certificates/tls.key"
+        readinessProbe:
+          exec:
+            command:
+            - "/bin/grpc_health_probe"
+            - "-addr=:50051"
+            - "-tls"
+            - "-tls-no-verify"
+          initialDelaySeconds: 5
+        livenessProbe:
+          exec:
+            command:
+            - "/bin/grpc_health_probe"
+            - "-addr=:50051"
+            - "-tls"
+            - "-tls-no-verify"
+          initialDelaySeconds: 10
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: server-certs
+          mountPath: /tmp/certificates
+          readOnly: true
+        - mountPath: /csi
+          name: socket-dir
+      volumes:
+      - name: server-certs
+        secret:
+          secretName: csi-dummyplugin-certs
+      - hostPath:
+          path: /var/lib/kubelet/plugins/cbt/csi-hostpath
+          type: DirectoryOrCreate
+        name: socket-dir

--- a/deploy/snapshot-metadata-cluster-role.yaml
+++ b/deploy/snapshot-metadata-cluster-role.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-snapshot-metadata-cluster-role
+rules:
+# To access snapshotmetadataservice resource
+- apiGroups:
+  - cbt.storage.k8s.io
+  resources:
+  - snapshotmetadataservices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+# To access tokenreviews and subjectaccessreviews APIs
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+  - get
+# To access volumesnapshot and volumesnapshotcontents
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list

--- a/deploy/snpashot-metadata-client-cluster-role.yaml
+++ b/deploy/snpashot-metadata-client-cluster-role.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-snapshot-metadata-client
+rules:
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+# Access to discover SnapshotMetadataService resources
+- apiGroups:
+  - cbt.storage.k8s.io
+  resources:
+  - snapshotmetadataservices
+  verbs:
+  - get
+  - list
+## Access to create sa tokens with tokenrequests API if client needs to generate SA token
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+  - get


### PR DESCRIPTION
### Change overview

- Add deployment manifests to setup sidecar server
- Update Dockerfile to add grpc-health-probe tool for liveness and readiness probe
- Set platform to build script to build amd64 images on mac
- For now, use mocked csi driver since no other driver implements snapshot metadata service
- The manifest repo uses images from a personal docker repo till we setup the CI and registry

Fixes: https://github.com/kubernetes-csi/external-snapshot-metadata/issues/8