### PR TITLE
Fix gRPC handler unit tests

### DIFF
--- a/pkg/internal/runtime/runtime_test.go
+++ b/pkg/internal/runtime/runtime_test.go
@@ -112,7 +112,7 @@ func TestNew(t *testing.T) {
 		assert.NotEmpty(t, expArgs.Kubeconfig)
 
 		// remove the fake driver name
-		th.FakeCSIDriverName = ""
+		th.driverName = ""
 
 		rt, err := New(expArgs)
 
@@ -127,7 +127,7 @@ func TestNew(t *testing.T) {
 		defer th.TerminateFakeCSIDriver(t)
 
 		expDriverName := "csi-driver-name"
-		th.FakeCSIDriverName = expDriverName
+		th.driverName = expDriverName
 
 		expArgs := th.RuntimeArgs()
 		assert.NotEmpty(t, expArgs.Kubeconfig)

--- a/pkg/internal/runtime/test_harness_test.go
+++ b/pkg/internal/runtime/test_harness_test.go
@@ -66,7 +66,7 @@ func TestRuntimeTestHarness(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, driverName)
 
-		th.FakeCSIDriverName = ""
+		th.driverName = ""
 		driverName, err = csirpc.GetDriverName(ctx, rt.CSIConn)
 		assert.Error(t, err)
 		assert.Empty(t, driverName)

--- a/pkg/internal/server/grpc/auth_test.go
+++ b/pkg/internal/server/grpc/auth_test.go
@@ -32,7 +32,7 @@ import (
 func TestAuthenticateAndAuthorize(t *testing.T) {
 	t.Run("crd-get-error", func(t *testing.T) {
 		th := newTestHarness()
-		s := th.ServerWithClientAPIs()
+		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
 		s.config.Runtime.DriverName += "foo"
 		assert.NotEqual(t, th.DriverName, s.driverName())
 
@@ -52,7 +52,7 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 
 	t.Run("crd-get-success", func(t *testing.T) {
 		th := newTestHarness()
-		s := th.ServerWithClientAPIs()
+		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
 
 		retAudience, err := s.getAudienceForDriver(context.Background())
 		assert.NoError(t, err)
@@ -61,7 +61,7 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 
 	t.Run("authentication-error", func(t *testing.T) {
 		th := newTestHarness()
-		s := th.ServerWithClientAPIs()
+		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
 
 		// intercept the creation and fail
 		kubeClient := s.config.Runtime.KubeClient.(*fake.Clientset)
@@ -86,7 +86,7 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 
 	t.Run("not-authenticated", func(t *testing.T) {
 		th := newTestHarness()
-		s := th.ServerWithClientAPIs()
+		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
 
 		// direct call
 		authenticated, ui, err := s.authenticateRequest(context.Background(), th.SecurityToken+"foo")
@@ -105,7 +105,7 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 
 	t.Run("authorization-error", func(t *testing.T) {
 		th := newTestHarness()
-		s := th.ServerWithClientAPIs()
+		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
 
 		// intercept the creation and fail
 		kubeClient := s.config.Runtime.KubeClient.(*fake.Clientset)
@@ -123,7 +123,7 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 
 	t.Run("not-authorized", func(t *testing.T) {
 		th := newTestHarness()
-		s := th.ServerWithClientAPIs()
+		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
 
 		err := s.authenticateAndAuthorize(context.Background(), th.SecurityToken, th.Namespace+"foo")
 		assert.Error(t, err)
@@ -135,7 +135,7 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		th := newTestHarness()
-		s := th.ServerWithClientAPIs()
+		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
 
 		err := s.authenticateAndAuthorize(context.Background(), th.SecurityToken, th.Namespace)
 		assert.NoError(t, err)

--- a/pkg/internal/server/grpc/health_test.go
+++ b/pkg/internal/server/grpc/health_test.go
@@ -27,7 +27,7 @@ import (
 func TestHealthService(t *testing.T) {
 	t.Run("state-transitions", func(t *testing.T) {
 		th := newTestHarness()
-		server := th.ServerWithClientAPIs()
+		server := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
 
 		assert.False(t, server.isReady())
 
@@ -49,7 +49,7 @@ func TestHealthService(t *testing.T) {
 
 	t.Run("client-health-checks", func(t *testing.T) {
 		th := newTestHarness()
-		server := th.StartGRPCServer(t)
+		server := th.StartGRPCServer(t, th.RuntimeWithClientAPIs())
 		defer th.StopGRPCServer(t)
 
 		client := th.GRPCHealthClient(t)

--- a/pkg/internal/server/grpc/validators_test.go
+++ b/pkg/internal/server/grpc/validators_test.go
@@ -30,7 +30,7 @@ import (
 func TestValidateGetMetadataAllocatedRequest(t *testing.T) {
 	ctx := context.Background()
 	th := newTestHarness()
-	grpcServer := th.StartGRPCServer(t)
+	grpcServer := th.StartGRPCServer(t, th.RuntimeWithClientAPIs())
 	defer th.StopGRPCServer(t)
 
 	for _, tc := range []struct {
@@ -109,7 +109,7 @@ func TestValidateGetMetadataAllocatedRequest(t *testing.T) {
 func TestValidateGetMetadataDeltaRequest(t *testing.T) {
 	ctx := context.Background()
 	th := newTestHarness()
-	grpcServer := th.StartGRPCServer(t)
+	grpcServer := th.StartGRPCServer(t, th.RuntimeWithClientAPIs())
 	defer th.StopGRPCServer(t)
 
 	for _, tc := range []struct {


### PR DESCRIPTION
- Mock CSI driver in gRPC request handlers unit tests
- Add test case about CSI response error