### PR TITLE
Propagate gRPC Status errors

### DIFF
--- a/pkg/internal/server/grpc/get_metadata_allocated.go
+++ b/pkg/internal/server/grpc/get_metadata_allocated.go
@@ -98,12 +98,12 @@ func (s *Server) streamGetMetadataAllocatedResponse(clientStream api.SnapshotMet
 		}
 
 		if err != nil {
-			return status.Errorf(codes.Internal, msgInternalFailedCSIDriverResponseFmt, err)
+			return s.statusPassOrWrapError(err, codes.Internal, msgInternalFailedCSIDriverResponseFmt, err)
 		}
 
 		clientResp := s.convertToGetMetadataAllocatedResponse(csiResp)
 		if err := clientStream.Send(clientResp); err != nil {
-			return status.Errorf(codes.Internal, msgInternalFailedtoSendResponseFmt, err)
+			return s.statusPassOrWrapError(err, codes.Internal, msgInternalFailedtoSendResponseFmt, err)
 		}
 	}
 }

--- a/pkg/internal/server/grpc/get_metadata_allocated_test.go
+++ b/pkg/internal/server/grpc/get_metadata_allocated_test.go
@@ -82,7 +82,7 @@ func TestGetMetadataAllocatedViaGRPCClient(t *testing.T) {
 			expStatusMsg:      msgUnavailableCSIDriverNotReady,
 		},
 		{
-			name:              "csi stream error",
+			name:              "csi stream non status error",
 			setCSIDriverReady: true,
 			req: &api.GetMetadataAllocatedRequest{
 				SecurityToken: th.SecurityToken,
@@ -90,10 +90,24 @@ func TestGetMetadataAllocatedViaGRPCClient(t *testing.T) {
 				SnapshotName:  "snap-1",
 			},
 			mockCSIResponse:   true,
-			mockCSIError:      fmt.Errorf("stream error"),
+			mockCSIError:      fmt.Errorf("not a status error"),
 			expectStreamError: true,
 			expStatusCode:     codes.Internal,
 			expStatusMsg:      msgInternalFailedCSIDriverResponse,
+		},
+		{
+			name:              "csi stream status error",
+			setCSIDriverReady: true,
+			req: &api.GetMetadataAllocatedRequest{
+				SecurityToken: th.SecurityToken,
+				Namespace:     th.Namespace,
+				SnapshotName:  "snap-1",
+			},
+			mockCSIResponse:   true,
+			mockCSIError:      status.Errorf(codes.Aborted, "is a status error"),
+			expectStreamError: true,
+			expStatusCode:     codes.Aborted, // code unchanged
+			expStatusMsg:      "is a status error",
 		},
 		{
 			name:              "success",

--- a/pkg/internal/server/grpc/get_metadata_delta.go
+++ b/pkg/internal/server/grpc/get_metadata_delta.go
@@ -112,12 +112,12 @@ func (s *Server) streamGetMetadataDeltaResponse(clientStream api.SnapshotMetadat
 		}
 
 		if err != nil {
-			return status.Errorf(codes.Internal, msgInternalFailedCSIDriverResponseFmt, err)
+			return s.statusPassOrWrapError(err, codes.Internal, msgInternalFailedCSIDriverResponseFmt, err)
 		}
 
 		clientResp := s.convertToGetMetadataDeltaResponse(csiResp)
 		if err := clientStream.Send(clientResp); err != nil {
-			return status.Errorf(codes.Internal, msgInternalFailedtoSendResponseFmt, err)
+			return s.statusPassOrWrapError(err, codes.Internal, msgInternalFailedtoSendResponseFmt, err)
 		}
 	}
 }

--- a/pkg/internal/server/grpc/get_metadata_delta_test.go
+++ b/pkg/internal/server/grpc/get_metadata_delta_test.go
@@ -84,7 +84,7 @@ func TestGetMetadataDeltaViaGRPCClient(t *testing.T) {
 			expStatusMsg:      msgUnavailableCSIDriverNotReady,
 		},
 		{
-			name:              "csi stream error",
+			name:              "csi stream non status error",
 			setCSIDriverReady: true,
 			req: &api.GetMetadataDeltaRequest{
 				SecurityToken:      th.SecurityToken,
@@ -93,10 +93,25 @@ func TestGetMetadataDeltaViaGRPCClient(t *testing.T) {
 				TargetSnapshotName: "snap-2",
 			},
 			mockCSIResponse:   true,
-			mockCSIError:      fmt.Errorf("stream error"),
+			mockCSIError:      fmt.Errorf("not a status error"),
 			expectStreamError: true,
 			expStatusCode:     codes.Internal,
 			expStatusMsg:      msgInternalFailedCSIDriverResponse,
+		},
+		{
+			name:              "csi stream status error",
+			setCSIDriverReady: true,
+			req: &api.GetMetadataDeltaRequest{
+				SecurityToken:      th.SecurityToken,
+				Namespace:          th.Namespace,
+				BaseSnapshotName:   "snap-1",
+				TargetSnapshotName: "snap-2",
+			},
+			mockCSIResponse:   true,
+			mockCSIError:      status.Errorf(codes.Aborted, "is a status error"),
+			expectStreamError: true,
+			expStatusCode:     codes.Aborted, // code unchanged
+			expStatusMsg:      "is a status error",
 		},
 		{
 			name:              "success",

--- a/pkg/internal/server/grpc/status.go
+++ b/pkg/internal/server/grpc/status.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package grpc
 
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
 const (
 	mgsInternalFailedToAuthorizePrefix    = "failed to authorize the user"
 	mgsInternalFailedToAuthorizeFmt       = mgsInternalFailedToAuthorizePrefix + ": %v"
@@ -54,3 +59,17 @@ const (
 	msgUnavailableInvalidVolumeSnapshotContentStatus    = "snapshotHandle is not set in VolumeSnapshotContent status"
 	msgUnavailableInvalidVolumeSnapshotContentStatusFmt = msgUnavailableInvalidVolumeSnapshotContentStatus + "name: %s"
 )
+
+// statusPassOrWrapError accepts an error and and returns it unchanged if it is nil or a gRPC Status with a code other than Unknown.
+// Otherwise it formats it as a gRPC Status with the given code, format string and arguments.
+func (s *Server) statusPassOrWrapError(err error, c codes.Code, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+
+	if statusError := status.Convert(err); statusError != nil && statusError.Code() != codes.Unknown {
+		return err
+	}
+
+	return status.Errorf(c, format, args...)
+}

--- a/pkg/internal/server/grpc/status_test.go
+++ b/pkg/internal/server/grpc/status_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestStatusPassOrWrapError(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		err := (&Server{}).statusPassOrWrapError(nil, codes.Internal, "internal error")
+		assert.Nil(t, err)
+	})
+
+	t.Run("non-status-error", func(t *testing.T) {
+		terr := errors.New("test-error")
+
+		err := (&Server{}).statusPassOrWrapError(terr, codes.Internal, "internal error: %v", terr)
+		assert.NotNil(t, err)
+		assert.NotEqual(t, terr, err)
+
+		se, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Internal, se.Code())
+		assert.Contains(t, se.Err().Error(), terr.Error())
+	})
+
+	t.Run("status-error", func(t *testing.T) {
+		terr := status.Errorf(codes.Canceled, "cancelled operation")
+
+		err := (&Server{}).statusPassOrWrapError(terr, codes.Internal, "internal error: %v", terr)
+		assert.NotNil(t, err)
+		assert.Equal(t, terr, err)
+
+		se, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Canceled, se.Code())
+		assert.Equal(t, se.Err().Error(), terr.Error())
+	})
+}


### PR DESCRIPTION
Handlers will directly pass on a grpc.Status derived error as long as its code is not Unknown.
Otherwise the error will be formatted into a gRPC.Status.

Fixes: https://github.com/kubernetes-csi/external-snapshot-metadata/issues/30
