### PR TITLE
Add unit test for convertCSIRequest handlers

### DIFF
--- a/pkg/internal/server/grpc/auth_test.go
+++ b/pkg/internal/server/grpc/auth_test.go
@@ -31,8 +31,8 @@ import (
 
 func TestAuthenticateAndAuthorize(t *testing.T) {
 	t.Run("crd-get-error", func(t *testing.T) {
-		th := newTestHarness()
-		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		s := th.ServerWithRuntime(t, th.Runtime())
 		s.config.Runtime.DriverName += "foo"
 		assert.NotEqual(t, th.DriverName, s.driverName())
 
@@ -51,8 +51,8 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 	})
 
 	t.Run("crd-get-success", func(t *testing.T) {
-		th := newTestHarness()
-		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		s := th.ServerWithRuntime(t, th.Runtime())
 
 		retAudience, err := s.getAudienceForDriver(context.Background())
 		assert.NoError(t, err)
@@ -60,8 +60,8 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 	})
 
 	t.Run("authentication-error", func(t *testing.T) {
-		th := newTestHarness()
-		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		s := th.ServerWithRuntime(t, th.Runtime())
 
 		// intercept the creation and fail
 		kubeClient := s.config.Runtime.KubeClient.(*fake.Clientset)
@@ -85,8 +85,8 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 	})
 
 	t.Run("not-authenticated", func(t *testing.T) {
-		th := newTestHarness()
-		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		s := th.ServerWithRuntime(t, th.Runtime())
 
 		// direct call
 		authenticated, ui, err := s.authenticateRequest(context.Background(), th.SecurityToken+"foo")
@@ -104,8 +104,8 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 	})
 
 	t.Run("authorization-error", func(t *testing.T) {
-		th := newTestHarness()
-		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		s := th.ServerWithRuntime(t, th.Runtime())
 
 		// intercept the creation and fail
 		kubeClient := s.config.Runtime.KubeClient.(*fake.Clientset)
@@ -122,8 +122,8 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 	})
 
 	t.Run("not-authorized", func(t *testing.T) {
-		th := newTestHarness()
-		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		s := th.ServerWithRuntime(t, th.Runtime())
 
 		err := s.authenticateAndAuthorize(context.Background(), th.SecurityToken, th.Namespace+"foo")
 		assert.Error(t, err)
@@ -134,8 +134,8 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		th := newTestHarness()
-		s := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		s := th.ServerWithRuntime(t, th.Runtime())
 
 		err := s.authenticateAndAuthorize(context.Background(), th.SecurityToken, th.Namespace)
 		assert.NoError(t, err)

--- a/pkg/internal/server/grpc/get_metadata_delta.go
+++ b/pkg/internal/server/grpc/get_metadata_delta.go
@@ -88,7 +88,7 @@ func (s *Server) convertToCSIGetMetadataDeltaRequest(ctx context.Context, req *a
 
 	targetSnapshotHandle, driver, err := s.getVolSnapshotInfo(ctx, req.Namespace, req.TargetSnapshotName)
 	if err != nil {
-		return nil, status.Errorf(codes.Unavailable, msgUnavailableVolumeSnapshotNotReady)
+		return nil, err
 	}
 
 	if driver != s.driverName() {

--- a/pkg/internal/server/grpc/health_test.go
+++ b/pkg/internal/server/grpc/health_test.go
@@ -26,8 +26,8 @@ import (
 
 func TestHealthService(t *testing.T) {
 	t.Run("state-transitions", func(t *testing.T) {
-		th := newTestHarness()
-		server := th.ServerWithRuntime(t, th.RuntimeWithClientAPIs())
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		server := th.ServerWithRuntime(t, th.Runtime())
 
 		assert.False(t, server.isReady())
 
@@ -48,8 +48,8 @@ func TestHealthService(t *testing.T) {
 	})
 
 	t.Run("client-health-checks", func(t *testing.T) {
-		th := newTestHarness()
-		server := th.StartGRPCServer(t, th.RuntimeWithClientAPIs())
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		server := th.StartGRPCServer(t, th.Runtime())
 		defer th.StopGRPCServer(t)
 
 		client := th.GRPCHealthClient(t)

--- a/pkg/internal/server/grpc/status.go
+++ b/pkg/internal/server/grpc/status.go
@@ -50,14 +50,14 @@ const (
 	msgUnavailableVolumeSnapshotNotReady         = "the VolumeSnapshot is not yet ready"
 	msgUnavailableVolumeSnapshotNotReadyFmt      = msgUnavailableVolumeSnapshotNotReady + ", name: %s"
 	msgUnavailableInvalidVolumeSnapshotStatus    = "boundVolumeSnapshotContentName is not set in VolumeSnapshot status"
-	msgUnavailableInvalidVolumeSnapshotStatusFmt = msgUnavailableInvalidVolumeSnapshotStatus + "name: %s"
+	msgUnavailableInvalidVolumeSnapshotStatusFmt = msgUnavailableInvalidVolumeSnapshotStatus + ", name: %s"
 
 	msgUnavailableFailedToGetVolumeSnapshotContent      = "failed to get VolumeSnapshotContent"
 	msgUnavailableFailedToGetVolumeSnapshotContentFmt   = msgUnavailableFailedToGetVolumeSnapshotContent + ": %v"
 	msgUnavailableVolumeSnapshotContentNotReady         = "the VolumeSnapshotContent is not yet ready"
 	msgUnavailableVolumeSnapshotContentNotReadyFmt      = msgUnavailableVolumeSnapshotContentNotReady + ", name: %s"
 	msgUnavailableInvalidVolumeSnapshotContentStatus    = "snapshotHandle is not set in VolumeSnapshotContent status"
-	msgUnavailableInvalidVolumeSnapshotContentStatusFmt = msgUnavailableInvalidVolumeSnapshotContentStatus + "name: %s"
+	msgUnavailableInvalidVolumeSnapshotContentStatusFmt = msgUnavailableInvalidVolumeSnapshotContentStatus + ", name: %s"
 )
 
 // statusPassOrWrapError accepts an error and and returns it unchanged if it is nil or a gRPC Status with a code other than Unknown.


### PR DESCRIPTION
- Refactor testHarness to initialize fake client and allow setting fake client PrependReactor at runtime
- Add unit tests for `convertToCSIGetMetadataAllocatedRequest` and `convertToCSIGetMetadataDeltaRequest` handlers