### PR TITLE
Use a contextual logger in the sidecar handlers.

### DIFF
--- a/pkg/internal/authn/token_auth.go
+++ b/pkg/internal/authn/token_auth.go
@@ -22,6 +22,7 @@ import (
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
 // TokenAuthenticator authenticates the user using K8s TokenReview API
@@ -45,6 +46,7 @@ func (t *TokenAuthenticator) Authenticate(ctx context.Context, token string, aud
 	}
 	auth, err := t.kubeClient.AuthenticationV1().TokenReviews().Create(ctx, &tokenReview, metav1.CreateOptions{})
 	if err != nil {
+		klog.FromContext(ctx).Error(err, "TokenReviews.Create", "audiences", audience)
 		return false, nil, err
 	}
 	if !auth.Status.Authenticated {

--- a/pkg/internal/authz/sar_authorizer.go
+++ b/pkg/internal/authz/sar_authorizer.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
 // SARAuthorizer authorizes user using K8s SubjectAccessReview API
@@ -52,6 +53,7 @@ func (s *SARAuthorizer) Authorize(ctx context.Context, userInfo *authv1.UserInfo
 	}
 	sarResp, err := s.kubeClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 	if err != nil {
+		klog.FromContext(ctx).Error(err, "SubjectAccessReviews.Create", "userInfo", userInfo)
 		return authorizer.DecisionDeny, "", err
 	}
 	if !sarResp.Status.Allowed || sarResp.Status.Denied {

--- a/pkg/internal/server/grpc/health.go
+++ b/pkg/internal/server/grpc/health.go
@@ -62,10 +62,12 @@ func (s *Server) shuttingDown() {
 
 // isCSIDriverReady is a helper for the handlers that returns the appropriate error if the
 // CSI driver is not ready.
-func (s *Server) isCSIDriverReady() error {
+func (s *Server) isCSIDriverReady(ctx context.Context) error {
 	if s.isReady() {
 		return nil
 	}
+
+	klog.FromContext(ctx).Error(nil, msgUnavailableCSIDriverNotReady, "driverName", s.driverName())
 
 	return status.Errorf(codes.Unavailable, msgUnavailableCSIDriverNotReady)
 }

--- a/pkg/internal/server/grpc/snapshot.go
+++ b/pkg/internal/server/grpc/snapshot.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 type volSnapshotInfo struct {
@@ -45,7 +46,7 @@ func (s *Server) getVolSnapshotInfo(ctx context.Context, namespace, vsName strin
 		sourceVolume = *vs.Spec.Source.PersistentVolumeClaimName
 	}
 
-	vsc, err := s.getVolumeSnapshotContent(ctx, *vs.Status.BoundVolumeSnapshotContentName)
+	vsc, err := s.getVolumeSnapshotContent(ctx, *vs.Status.BoundVolumeSnapshotContentName, vsName)
 	if err != nil {
 		return nil, err
 	}
@@ -62,31 +63,37 @@ func (s *Server) getVolSnapshotInfo(ctx context.Context, namespace, vsName strin
 func (s *Server) getVolumeSnapshot(ctx context.Context, namespace, vsName string) (*snapshotv1.VolumeSnapshot, error) {
 	vs, err := s.snapshotClient().SnapshotV1().VolumeSnapshots(namespace).Get(ctx, vsName, metav1.GetOptions{})
 	if err != nil {
+		klog.FromContext(ctx).Error(err, msgUnavailableFailedToGetVolumeSnapshot, "vsName", vsName)
 		return nil, status.Errorf(codes.Unavailable, msgUnavailableFailedToGetVolumeSnapshotFmt, namespace, vsName, err)
 	}
 
 	if vs.Status.ReadyToUse == nil || !*vs.Status.ReadyToUse {
+		klog.FromContext(ctx).Error(err, msgUnavailableVolumeSnapshotNotReady, "vsName", vsName)
 		return nil, status.Errorf(codes.Unavailable, msgUnavailableVolumeSnapshotNotReadyFmt, vsName)
 	}
 
 	if vs.Status.BoundVolumeSnapshotContentName == nil {
+		klog.FromContext(ctx).Error(err, msgUnavailableInvalidVolumeSnapshotStatus, "vsName", vsName)
 		return nil, status.Errorf(codes.Unavailable, msgUnavailableInvalidVolumeSnapshotStatusFmt, vsName)
 	}
 
 	return vs, nil
 }
 
-func (s *Server) getVolumeSnapshotContent(ctx context.Context, vscName string) (*snapshotv1.VolumeSnapshotContent, error) {
+func (s *Server) getVolumeSnapshotContent(ctx context.Context, vscName, vsName string) (*snapshotv1.VolumeSnapshotContent, error) {
 	vsc, err := s.snapshotClient().SnapshotV1().VolumeSnapshotContents().Get(ctx, vscName, metav1.GetOptions{})
 	if err != nil {
+		klog.FromContext(ctx).Error(err, msgUnavailableFailedToGetVolumeSnapshotContent, "vscName", vscName, "vsName", vsName)
 		return nil, status.Errorf(codes.Unavailable, msgUnavailableFailedToGetVolumeSnapshotContentFmt, vscName, err)
 	}
 
 	if vsc.Status.ReadyToUse == nil || !*vsc.Status.ReadyToUse {
+		klog.FromContext(ctx).Error(err, msgUnavailableVolumeSnapshotContentNotReady, "vscName", vscName, "vsName", vsName)
 		return nil, status.Errorf(codes.Unavailable, msgUnavailableVolumeSnapshotContentNotReadyFmt, vscName)
 	}
 
 	if vsc.Status.SnapshotHandle == nil {
+		klog.FromContext(ctx).Error(err, msgUnavailableInvalidVolumeSnapshotContentStatus, "vscName", vscName, "vsName", vsName)
 		return nil, status.Errorf(codes.Unavailable, msgUnavailableInvalidVolumeSnapshotContentStatusFmt, vscName)
 	}
 

--- a/pkg/internal/server/grpc/status.go
+++ b/pkg/internal/server/grpc/status.go
@@ -22,12 +22,14 @@ import (
 )
 
 const (
-	mgsInternalFailedToAuthorizePrefix    = "failed to authorize the user"
 	mgsInternalFailedToAuthorizeFmt       = mgsInternalFailedToAuthorizePrefix + ": %v"
-	msgInternalFailedToAuthenticatePrefix = "failed to authenticate user"
-	msgInternalFailedToAuthenticateFmt    = msgInternalFailedToAuthenticatePrefix + ": %v"
+	mgsInternalFailedToAuthorizePrefix    = "failed to authorize the user"
 	msgInternalFailedCSIDriverResponse    = "failed to get response from CSI driver"
 	msgInternalFailedCSIDriverResponseFmt = msgInternalFailedCSIDriverResponse + ": %v"
+	msgInternalFailedToAuthenticateFmt    = msgInternalFailedToAuthenticatePrefix + ": %v"
+	msgInternalFailedToAuthenticatePrefix = "failed to authenticate user"
+	msgInternalFailedToFindCR             = "failed to find the SnapshotMetadataService CR for driver"
+	msgInternalFailedToFindCRFmt          = msgInternalFailedToFindCR + " '%s': %v"
 	msgInternalFailedToSendResponse       = "failed to send response"
 	msgInternalFailedtoSendResponseFmt    = msgInternalFailedToSendResponse + ": %v"
 


### PR DESCRIPTION
The logger is initialized with values from the handler call, and generates a distinct operation identifier for each specific invocation.  The logger is embedded in a context derived from the stream context. This context then gets passed to all function calls made in the handler. Every use of the contextual logger automatically prints the original values along with any additional values specified. As this includes the distinct operation identifier this helps in tracing the output from concurrent handler calls.

Fixes: https://github.com/kubernetes-csi/external-snapshot-metadata/issues/35
