### PR TITLE
Verify base and target snapshot belong to the same volume

### DIFF
--- a/pkg/internal/server/grpc/get_metadata_delta.go
+++ b/pkg/internal/server/grpc/get_metadata_delta.go
@@ -95,6 +95,10 @@ func (s *Server) convertToCSIGetMetadataDeltaRequest(ctx context.Context, req *a
 		return nil, status.Errorf(codes.InvalidArgument, msgInvalidArgumentSnaphotDriverInvalidFmt, req.TargetSnapshotName, s.driverName())
 	}
 
+	if vsiBase.SourceVolume != vsiTarget.SourceVolume {
+		return nil, status.Errorf(codes.InvalidArgument, msgInvalidArgumentDiffSnapshotSourceVolumes)
+	}
+
 	// the target was created after the base so use its secrets.
 	secretsMap, err := s.getSnapshotterCredentials(ctx, vsiTarget)
 	if err != nil {

--- a/pkg/internal/server/grpc/snapshot.go
+++ b/pkg/internal/server/grpc/snapshot.go
@@ -28,6 +28,7 @@ import (
 type volSnapshotInfo struct {
 	DriverName                string
 	SnapshotHandle            string
+	SourceVolume              string
 	VolumeSnapshot            *snapshotv1.VolumeSnapshot
 	VolumeSnapshotContentName string
 }
@@ -39,6 +40,11 @@ func (s *Server) getVolSnapshotInfo(ctx context.Context, namespace, vsName strin
 		return nil, err
 	}
 
+	sourceVolume := ""
+	if vs.Spec.Source.PersistentVolumeClaimName != nil {
+		sourceVolume = *vs.Spec.Source.PersistentVolumeClaimName
+	}
+
 	vsc, err := s.getVolumeSnapshotContent(ctx, *vs.Status.BoundVolumeSnapshotContentName)
 	if err != nil {
 		return nil, err
@@ -47,6 +53,7 @@ func (s *Server) getVolSnapshotInfo(ctx context.Context, namespace, vsName strin
 	return &volSnapshotInfo{
 		DriverName:                vsc.Spec.Driver,
 		SnapshotHandle:            *vsc.Status.SnapshotHandle,
+		SourceVolume:              sourceVolume,
 		VolumeSnapshot:            vs,
 		VolumeSnapshotContentName: vsc.Name,
 	}, nil

--- a/pkg/internal/server/grpc/status.go
+++ b/pkg/internal/server/grpc/status.go
@@ -37,6 +37,7 @@ const (
 	msgInvalidArgumentSnaphotNameMissing        = "snapshotName cannot be empty"
 	msgInvalidArgumentTargetSnapshotNameMissing = "targetSnapshotName cannot be empty"
 	msgInvalidArgumentSnaphotDriverInvalidFmt   = "VolumeSnapshot '%s' does not belong to the CSI driver '%s'"
+	msgInvalidArgumentDiffSnapshotSourceVolumes = "baseSnapshot and targetSnapshot does not belong to the same volume"
 
 	msgPermissionDeniedPrefix = "user does not have permissions to perform the operation"
 	msgPermissionDeniedFmt    = msgPermissionDeniedPrefix + ": %s"


### PR DESCRIPTION
Add a check to verify base and target snapshot belong to the same source volume

fixes: https://github.com/kubernetes-csi/external-snapshot-metadata/issues/36