### PR TITLE
build: Add golangci-lint make target

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,65 @@
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - copyloopvar
+    - dogsled
+    - dupl
+    - funlen
+    - gci
+    - gocognit
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goprintffuncname
+    - importas
+    - lll
+    - misspell
+    - nakedret
+    - nestif
+    - nolintlint
+    - staticcheck
+    - stylecheck
+    - unparam
+    - whitespace
+
+run:
+  timeout: 10m
+
+issues:
+  exclude-dirs:
+    - ^client/    # generated code
+    - ^pkg/api/   # generated code
+  exclude-files:
+    - ^release-tools/filter-junit.go
+  exclude-rules:
+    - path: _test\.go$
+      linters:
+        - dupl
+        - funlen
+        - gci
+        - gocognit
+        - gocritic
+        - gocyclo
+        - lll
+        - nestif
+        - unparam
+
+linters-settings:
+  funlen:
+    lines: 240
+    statements: 160
+  gocognit:
+    min-complexity: 20
+  gocyclo:
+    min-complexity: 20
+  lll:
+    line-length: 240
+  nakedret:
+    max-func-lines: 2
+  nestif:
+    min-complexity: 6
+  staticcheck:
+    checks: [ "all", "-ST1000", "-ST1003", "-ST1016" ]
+  stylecheck:
+    checks: [ "all", "-ST1001", "-ST1005", "-ST1016", "-ST1023", "-ST1000"]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,8 +28,10 @@ run:
 
 issues:
   exclude-dirs:
-    - ^client/    # generated code
-    - ^pkg/api/   # generated code
+    - ^client/            # generated code
+    - ^pkg/api/           # generated code
+    - ^pkg/csiclientmocks # generated code
+    - ^pkg/k8sclientmocks # generated code
   exclude-files:
     - ^release-tools/filter-junit.go
   exclude-rules:

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,3 @@ include release-tools/build.make
 .PHONY: test
 # Extend the test target to include lint
 test: lint
-	$(MAKE) -f release-tools/build.make test

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,5 @@ CMDS=csi-snapshot-metadata
 
 include release-tools/build.make
 
-.PHONY: test
 # Extend the test target to include lint
 test: lint

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ proto:
 crd:
 	@ cd client && ./hack/update-crd.sh
 
+.PHONY: lint
+# Run golangci-lint
+lint:
+	golangci-lint run
+
 
 # Include release-tools
 

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,8 @@ lint:
 CMDS=csi-snapshot-metadata
 
 include release-tools/build.make
+
+.PHONY: test
+# Extend the test target to include lint
+test: lint
+	$(MAKE) -f release-tools/build.make test


### PR DESCRIPTION
- Added `.golangci.yml` configuration file to modify golangci-lint settings 
The configuration I have added is aggressive. We could always revisit the rules if required.
- Added `make lint` target to the Makefile
- Extended `make test` target to include linting

Fixes: #14 