### PR TITLE
add trivy vulnerability scanner github action

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,0 +1,34 @@
+---
+name: Trivy vulnerability scanner
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ^1.19
+      
+      - name: Build images from Dockerfile
+        run: |
+          make
+          docker build -t test/csi-snapshot-metadata:latest -f ./cmd/csi-snapshot-metadata/Dockerfile --output=type=docker --label revision=latest .
+
+      - name: Run Trivy vulnerability scanner on csi-snapshot-metadata image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'test/csi-snapshot-metadata:latest'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'

--- a/cmd/csi-snapshot-metadata/Dockerfile
+++ b/cmd/csi-snapshot-metadata/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine AS builder
-ARG GRPC_HEALTH_PROBE_VERSION=v0.4.13
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.34
 ADD https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 /bin/grpc_health_probe
 RUN chmod +x /bin/grpc_health_probe
 


### PR DESCRIPTION
grpc health probe version needed an update to satisfy trivy scanner.

did action testing @ https://github.com/Rakshith-R/external-snapshot-metadata/pull/3