### PR TITLE
api: add api-approved.kubernetes.io annotation to CRD

### DIFF
--- a/client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml
+++ b/client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshot-metadata/pull/2"
   name: snapshotmetadataservices.cbt.storage.k8s.io
 spec:
   group: cbt.storage.k8s.io


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This commit adds the following annotation
`api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshot-metadata/pull/2"`.

Refer to https://github.com/kubernetes/enhancements/pull/1111 for more details.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
