### PR TITLE
metrics: add utility to record metrics for sidecar

### DIFF
--- a/pkg/internal/runtime/runtime.go
+++ b/pkg/internal/runtime/runtime.go
@@ -52,6 +52,10 @@ type Args struct {
 	TLSCertFile string
 	// Absolute path to the TLS key file.
 	TLSKeyFile string
+	// HttpEndpoint is the address of the metrics sever
+	HttpEndpoint string
+	// MetricsPath is the path where metrics will be recorded
+	MetricsPath string
 }
 
 func (args *Args) Validate() error {
@@ -169,7 +173,9 @@ func (rt *Runtime) kubeConnect(kubeconfig string, kubeAPIQPS float32, kubeAPIBur
 func (rt *Runtime) csiConnect(csiAddress string) error {
 	ctx := context.Background()
 
-	metricsManager := metrics.NewCSIMetricsManagerForSidecar("" /* driverName */)
+	metricsManager := metrics.NewCSIMetricsManagerWithOptions("",
+		metrics.WithSubsystem(SubSystem),
+		metrics.WithLabelNames(LabelTargetSnapshotName, LabelBaseSnapshotName))
 	csiConn, err := connection.Connect(
 		ctx,
 		csiAddress,

--- a/pkg/internal/runtime/util_metrics.go
+++ b/pkg/internal/runtime/util_metrics.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	LabelTargetSnapshotName = "target_snapshot"
+	LabelBaseSnapshotName   = "base_snapshot"
+	SubSystem               = "snapshot_metadata_controller"
+
+	// MetadataAllocatedOperationName is the operation that tracks how long the controller takes to get the allocated blocks for a snapshot.
+	// Specifically, the operation metric is emitted based on the following timestamps:
+	// - Start_time: controller notices the first time that there is a GetMetadataAllocated RPC call to fetch the allocated blocks of metadata
+	// - End_time:   controller notices that the RPC call is finished and the allocated blocks is streamed back to the driver
+	MetadataAllocatedOperationName = "MetadataAllocated"
+
+	// MetadataDeltaOperationName is the operation that tracks how long the controller takes to get the changed blocks between 2 snapshots
+	// Specifically, the operation metric is emitted based on the following timestamps:
+	// - Start_time: controller notices the first time that there is a GetMetadataDelta RPC call to fetch the changed blocks between 2 snapshots
+	// - End_time:   controller notices that the RPC call is finished and the changed blocks is streamed back to the driver
+	MetadataDeltaOperationName = "MetadataDelta"
+)
+
+// RecordMetricsWithLabels is a wrapper on the csi-lib-utils RecordMetrics function, that calls the
+// "RecordMetrics" functions with the necessary labels added to the MetricsManager runtime.
+func (rt *Runtime) RecordMetricsWithLabels(opLabel map[string]string, opName string, startTime time.Time, opErr error) {
+	metricsWithLabel, err := rt.MetricsManager.WithLabelValues(opLabel)
+	if err != nil {
+		klog.Error(err, "failed to add labels to metrics")
+		return
+	}
+
+	opDuration := time.Since(startTime)
+	metricsWithLabel.RecordMetrics(opName, opErr, opDuration)
+}

--- a/pkg/internal/server/grpc/common_test.go
+++ b/pkg/internal/server/grpc/common_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/metrics"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	fakesnapshot "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/fake"
 	snapshotutils "github.com/kubernetes-csi/external-snapshotter/v8/pkg/utils"
@@ -112,6 +113,7 @@ func (th *testHarness) Runtime() *runtime.Runtime {
 		SnapshotClient: th.FakeSnapshotClient,
 		DriverName:     th.DriverName,
 		CSIConn:        th.mockCSIDriverConn,
+		MetricsManager: metrics.NewCSIMetricsManagerWithOptions(th.DriverName, metrics.WithSubsystem(runtime.SubSystem), metrics.WithLabelNames(runtime.LabelTargetSnapshotName, runtime.LabelBaseSnapshotName)),
 	}
 }
 

--- a/pkg/internal/server/grpc/get_metadata_allocated_test.go
+++ b/pkg/internal/server/grpc/get_metadata_allocated_test.go
@@ -151,6 +151,31 @@ func TestGetMetadataAllocatedViaGRPCClient(t *testing.T) {
 			} else if errStream != nil {
 				assert.ErrorIs(t, errStream, io.EOF)
 			}
+
+			// Validate metrics are recorded correctly
+			metrics, _ := grpcServer.config.Runtime.MetricsManager.GetRegistry().Gather()
+			statusFound := 0
+			snapshotFound := 0
+
+			// Validate that both gauge and controller metrics is recorded
+			assert.GreaterOrEqual(t, 2, len(metrics))
+			assert.Equal(t, *metrics[0].Name, "process_start_time_seconds")
+			assert.Equal(t, *metrics[1].Name, "snapshot_metadata_controller_operations_seconds")
+
+			// Validate grpc_status_code and target_snapshot name
+			for _, metric := range metrics[1].Metric {
+				for _, labels := range metric.Label {
+					expTargetSnapshotName := fmt.Sprintf("%s/%s", tc.req.Namespace, tc.req.SnapshotName)
+					if *labels.Name == "grpc_status_code" && *labels.Value == tc.expStatusCode.String() {
+						statusFound = 1
+					}
+					if *labels.Name == "target_snapshot" && *labels.Value == expTargetSnapshotName {
+						snapshotFound = 1
+					}
+				}
+			}
+			assert.Equal(t, 1, statusFound)
+			assert.Equal(t, 1, snapshotFound)
 		})
 	}
 }


### PR DESCRIPTION
Enable prometheus metrics for the sidecar using the csi-lib-utils metrics package. The httpServer for metrics can be enable by adding the httpEndpoint arg to the sidecar. The server will record metrics for operations like GetMetadataAllocated, GetMetadataDelta in the format
`snapshot_metadata_controller_operation_total_seconds_bucket{driver_name="",operation_name="",operation_status="",target_snapshot="", base_snapshot="",le="0.1"}`, for GetMetaAllocated operations "base_snapshot"
value will be empty.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR enables recording prometheus metrics for the snapshot-metadata sidecar.

**Which issue(s) this PR fixes**:
Fixes #11

**Does this PR introduce a user-facing change?**:
```release-note
Enable prometheus metrics for the snapshot-metatadata sidecar
```
