### PR TITLE
The snapshot iterator now determines the ServiceAccount if unspecified.

### DIFF
--- a/examples/snapshot-metadata-lister/main.go
+++ b/examples/snapshot-metadata-lister/main.go
@@ -50,6 +50,9 @@ If a previous VolumeSnapshot object is also specified then the metadata
 describes the content changes between the two snapshots, which must both
 be from the same PersistentVolume.
 
+The command is usually invoked in a Pod in the cluster, as the gRPC client
+needs to resolve the DNS address in the SnapshotMetadataService CR.
+
 ` + shortUsageFmt + `
 
 Flags:
@@ -80,7 +83,7 @@ func parseFlags() {
 		flag.StringVar(&kubeConfig, "kubeconfig", "", "Path to the kubeconfig file.")
 	}
 
-	flag.StringVar(&args.ServiceAccount, "service-account", "default", "ServiceAccount used to create a security token.")
+	flag.StringVar(&args.ServiceAccount, "service-account", "", "ServiceAccount used to create a security token. If unspecified the ServiceAccount of the Pod in which the command is invoked will be used.")
 
 	flag.Int64Var(&args.TokenExpirySecs, "token-expiry", 600, "Expiry time in seconds for the security token.")
 	flag.Int64Var(&args.StartingOffset, "starting-offset", 0, "The starting byte offset.")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Provide a default for ServiceAccount which picks up a Pod's ServiceAccount automatically.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
