### PR TITLE
Client error propagation

### DIFF
--- a/pkg/internal/server/grpc/get_metadata_allocated_test.go
+++ b/pkg/internal/server/grpc/get_metadata_allocated_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
@@ -750,4 +751,81 @@ func (f *fakeStreamServerSnapshotAllocated) Send(m *api.GetMetadataAllocatedResp
 
 func (f *fakeStreamServerSnapshotAllocated) verifyResponse(expectedResponse *api.GetMetadataAllocatedResponse) bool {
 	return f.response.String() == expectedResponse.String()
+}
+
+func TestGetMetadataAllocatedClientErrorHandling(t *testing.T) {
+	t.Run("client-cancels-context", func(t *testing.T) {
+		sms, th := newSMSHarnessForCtxPropagation(t, 0)
+		defer sms.cleanup(t)
+
+		// create the cancelable application client context
+		ctx, cancelFn := context.WithCancel(context.Background())
+
+		// make the RPC call
+		client := th.GRPCSnapshotMetadataClient(t)
+		clientStream, err := client.GetMetadataAllocated(ctx, &api.GetMetadataAllocatedRequest{
+			SecurityToken: th.SecurityToken,
+			Namespace:     th.Namespace,
+			SnapshotName:  "snap-1",
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, clientStream)
+
+		sms.synchronizeBeforeCancel()
+
+		r1, e1 := clientStream.Recv() // get the first response
+		assert.NoError(t, e1)
+		assert.NotNil(t, r1)
+
+		// the client cancels the context
+		cancelFn()
+
+		r2, e2 := clientStream.Recv() // fail because ctx is canceled
+		assert.Error(t, e2)
+		assert.ErrorContains(t, e2, context.Canceled.Error())
+		assert.Nil(t, r2)
+
+		sms.synchronizeAfterCancel()
+
+		// Check the fake driver handler status
+		sms.mux.Lock()
+		defer sms.mux.Unlock()
+		assert.True(t, sms.handlerCalled)
+		assert.NoError(t, sms.send1Err)
+		assert.ErrorIs(t, sms.streamCtxErr, context.Canceled)
+		assert.Error(t, sms.send2Err)
+		assert.ErrorContains(t, sms.send2Err, context.Canceled.Error())
+	})
+
+	t.Run("sidecar-deadline-exceeded", func(t *testing.T) {
+		// arrange for the sidecar to timeout quickly
+		sms, th := newSMSHarnessForCtxPropagation(t, time.Millisecond*10)
+		defer sms.cleanup(t)
+
+		// make the RPC call
+		client := th.GRPCSnapshotMetadataClient(t)
+		clientStream, err := client.GetMetadataAllocated(context.Background(), &api.GetMetadataAllocatedRequest{
+			SecurityToken: th.SecurityToken,
+			Namespace:     th.Namespace,
+			SnapshotName:  "snap-1",
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, clientStream)
+
+		sms.synchronizeBeforeCancel()
+
+		// do not attempt to receive anything
+
+		sms.synchronizeAfterCancel()
+
+		// Check the fake driver handler status
+		sms.mux.Lock()
+		defer sms.mux.Unlock()
+		assert.True(t, sms.handlerCalled)
+		assert.NoError(t, sms.send1Err)
+		assert.Error(t, sms.send2Err)
+		// its a bit uncertain as to which context error we get in the handler
+		re := context.DeadlineExceeded.Error() + "|" + context.Canceled.Error()
+		assert.Regexp(t, re, sms.send2Err.Error())
+	})
 }

--- a/pkg/internal/server/grpc/server_test.go
+++ b/pkg/internal/server/grpc/server_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
@@ -75,6 +76,7 @@ func TestNewServer(t *testing.T) {
 		assert.NotNil(t, s)
 		assert.NotNil(t, s.grpcServer)
 		assert.Equal(t, s.config.Runtime, &rt)
+		assert.Equal(t, HandlerDefaultMaxStreamDuration, s.config.MaxStreamDur)
 
 		err = s.Start()
 		assert.Error(t, err)
@@ -89,11 +91,16 @@ func TestNewServer(t *testing.T) {
 		rt.TLSCertFile = rta.TLSCertFile
 		rt.TLSKeyFile = rta.TLSKeyFile
 
-		s, err := NewServer(ServerConfig{Runtime: &rt})
+		expMaxStreamDur := HandlerDefaultMaxStreamDuration + time.Minute
+		s, err := NewServer(ServerConfig{
+			Runtime:      &rt,
+			MaxStreamDur: expMaxStreamDur,
+		})
 		assert.NoError(t, err)
 		assert.NotNil(t, s)
 		assert.NotNil(t, s.grpcServer)
 		assert.Equal(t, s.config.Runtime, &rt)
+		assert.Equal(t, expMaxStreamDur, s.config.MaxStreamDur)
 		assert.False(t, s.isReady()) // initialized to not ready
 
 		err = s.Start()


### PR DESCRIPTION
Ensure that client errors (context cancellation or failure to read responses) will result in the CSI driver stream being canceled.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This ensures that when a client aborts its receive stream, or stops reading responses, or the network connection between the client and the sidecar fails, the CSI driver stream will get canceled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #66

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
