### PR TITLE
Correct kubeclient init and parameters in snapshot-metadata-lister

### DIFF
--- a/examples/snapshot-metadata-lister/main.go
+++ b/examples/snapshot-metadata-lister/main.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"path/filepath"
 
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 
@@ -132,7 +133,7 @@ func main() {
 	parseFlags()
 
 	// get the K8s config from either kubeConfig, in-cluster or default
-	config, err := clientcmd.BuildConfigFromFlags("", kubeConfig)
+	config, err := buildConfig(kubeConfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading kubeconfig %s: %v\n", kubeConfig, err)
 		os.Exit(1)
@@ -155,4 +156,13 @@ func main() {
 	}
 
 	os.Exit(0)
+}
+
+func buildConfig(kubeconfigPath string) (*rest.Config, error) {
+	// If kubeconfig exists, try from kubeconfig file
+	if _, err := os.Stat(kubeconfigPath); err == nil {
+		return clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	}
+	// try in-cluster config
+	return rest.InClusterConfig()
 }

--- a/pkg/iterator/common_test.go
+++ b/pkg/iterator/common_test.go
@@ -271,7 +271,7 @@ func (th *testHarness) getSnapshotMetadataServiceCR(ctx context.Context, csiDriv
 	return th.RetGetSnapshotMetadataServiceCRService, th.RetGetSnapshotMetadataServiceCRErr
 }
 
-func (th *testHarness) createSecurityToken(ctx context.Context, saName, saNamespace, audience string) (string, error) {
+func (th *testHarness) createSecurityToken(ctx context.Context, saNamespace, saName, audience string) (string, error) {
 	th.InCreateSecurityTokenSAName = saName
 	th.InCreateSecurityTokenSANamespace = saNamespace
 	th.InCreateSecurityTokenAudience = audience

--- a/pkg/iterator/common_test.go
+++ b/pkg/iterator/common_test.go
@@ -258,7 +258,7 @@ func (th *testHarness) SnapshotMetadataIteratorDone(numberRecords int) {
 // fake helpers
 func (th *testHarness) getDefaultServiceAccount(ctx context.Context) (string, string, error) {
 	th.CalledGetDefaultServiceAccount = true
-	return th.RetGetDefaultSAName, th.RetGetDefaultSANamespace, th.RetGetDefaultServiceAccountErr
+	return th.RetGetDefaultSANamespace, th.RetGetDefaultSAName, th.RetGetDefaultServiceAccountErr
 }
 
 func (th *testHarness) getCSIDriverFromPrimarySnapshot(ctx context.Context) (string, error) {

--- a/pkg/iterator/iter.go
+++ b/pkg/iterator/iter.go
@@ -167,7 +167,7 @@ type iterator struct {
 
 type iteratorHelpers interface {
 	getCSIDriverFromPrimarySnapshot(ctx context.Context) (string, error)
-	getDefaultServiceAccount(ctx context.Context) (string, string, error)
+	getDefaultServiceAccount(ctx context.Context) (saNamespace string, saName string, err error)
 	getSnapshotMetadataServiceCR(ctx context.Context, csiDriver string) (*smsCRv1alpha1.SnapshotMetadataService, error)
 	createSecurityToken(ctx context.Context, saNamespace, saName, audience string) (string, error)
 	getGRPCClient(caCert []byte, URL string) (api.SnapshotMetadataClient, error)

--- a/pkg/iterator/iter.go
+++ b/pkg/iterator/iter.go
@@ -296,7 +296,7 @@ func (iter *iterator) getSnapshotMetadataServiceCR(ctx context.Context, csiDrive
 
 // createSecurityToken will create a security token for the specified storage
 // account using the audience string from the SnapshotMetadataService CR.
-func (iter *iterator) createSecurityToken(ctx context.Context, sa, saNamespace, audience string) (string, error) {
+func (iter *iterator) createSecurityToken(ctx context.Context, saNamespace, sa, audience string) (string, error) {
 	tokenRequest := authv1.TokenRequest{
 		Spec: authv1.TokenRequestSpec{
 			Audiences:         []string{audience},

--- a/pkg/iterator/iter_test.go
+++ b/pkg/iterator/iter_test.go
@@ -489,7 +489,7 @@ func TestCreateSecurityToken(t *testing.T) {
 		th := newTestHarness()
 		iter := th.NewTestIterator()
 
-		securityToken, err := iter.createSecurityToken(context.Background(), th.SAName, th.SANamespace, th.Audience)
+		securityToken, err := iter.createSecurityToken(context.Background(), th.SANamespace, th.SAName, th.Audience)
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "ServiceAccounts.CreateToken")
 		assert.Empty(t, securityToken)
@@ -503,7 +503,7 @@ func TestCreateSecurityToken(t *testing.T) {
 			return true, th.FakeTokenRequest(), nil
 		})
 
-		securityToken, err := iter.createSecurityToken(context.Background(), th.SAName, th.SANamespace, th.Audience)
+		securityToken, err := iter.createSecurityToken(context.Background(), th.SANamespace, th.SAName, th.Audience)
 		assert.NoError(t, err)
 		assert.Equal(t, th.SecurityToken, securityToken)
 	})


### PR DESCRIPTION

**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:

This PR fixes few issues found while testing the client inside a pod:

- Adds support to initialize kubernetes client from inside pod
- Corrects parameter order in  createSecurityToken()

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
