### PR TITLE
Fix timeout duration calculation

### DIFF
--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -228,7 +228,7 @@ func (s *sidecarFlagSet) runtimeArgsToArgv(progName string, rta runtime.Args) []
 func (s *sidecarFlagSet) createServerConfig(rt *runtime.Runtime) grpc.ServerConfig {
 	return grpc.ServerConfig{
 		Runtime:      rt,
-		MaxStreamDur: time.Duration(*s.maxStreamingDurMin * 60),
+		MaxStreamDur: time.Duration(*s.maxStreamingDurMin) * time.Minute,
 	}
 }
 

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -117,7 +117,7 @@ func TestSidecarFlagSet(t *testing.T) {
 		rt := &runtime.Runtime{}
 		config := sfs.createServerConfig(rt)
 		assert.Equal(t, rt, config.Runtime)
-		assert.Equal(t, time.Duration(defaultMaxStreamingDurationMin*60), config.MaxStreamDur)
+		assert.Equal(t, time.Duration(defaultMaxStreamingDurationMin)*time.Minute, config.MaxStreamDur)
 	})
 }
 


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR fixes incorrect calculation of stream timeout which was causing context calculation earlier than expected.

**Which issue(s) this PR fixes**:
Fixes #99 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
