### PR TITLE
update grpc-health-probe and re-enable triv scanner gh action

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-  # TODO: revert once https://github.com/grpc-ecosystem/grpc-health-probe/issues/230 is fixed 
-  # pull_request:
+  pull_request:
 jobs:
   build:
     name: Build

--- a/cmd/csi-snapshot-metadata/Dockerfile
+++ b/cmd/csi-snapshot-metadata/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine AS builder
-ARG GRPC_HEALTH_PROBE_VERSION=v0.4.36
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.37
 ADD https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 /bin/grpc_health_probe
 RUN chmod +x /bin/grpc_health_probe
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

- updates grpc-health-probe to 0.4.37
- re-enables trivy scanner gh action

**Which issue(s) this PR fixes**:

Fixes #100

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
