### PR TITLE
Add support for passing audience token through cmdline arguement

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -6,8 +6,11 @@ on:
 
 jobs:
   minikube-ci:
-    name: Intergration test
+    name: Integration test (with${{ matrix.audience == false && 'out' || '' }} audience parameter)
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        audience: [false, true]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -29,6 +32,13 @@ jobs:
       - name: Deploy snapshot-controller
         run: |
           ./scripts/deploy-snapshot-controller.sh deploy
+
+      - name: Configure audience parameter
+        run: |
+          if [ "${{ matrix.audience }}" = "true" ]; then
+            echo "Enabling audience parameter"
+            sed -i 's/# - "--audience=test-backup-client"/- "--audience=test-backup-client"/' deploy/example/csi-driver/csi-driver-with-snapshot-metadata-sidecar.yaml
+          fi
 
       - name: Deploy csi-hostpath-driver
         run: |

--- a/deploy/example/csi-driver/csi-driver-with-snapshot-metadata-sidecar.yaml
+++ b/deploy/example/csi-driver/csi-driver-with-snapshot-metadata-sidecar.yaml
@@ -29,6 +29,10 @@ spec:
           - "--csi-address=/csi/csi.sock"
           - "--tls-cert=/tmp/certificates/tls.crt"
           - "--tls-key=/tmp/certificates/tls.key"
+          # (optional) audience token string can be passed here.
+          # If specified, the sidecar will use this instead of
+          # fetching the token from SnapshotMetadataService CR.
+          # - "--audience=test-backup-client"
           readinessProbe:
             exec:
               command:

--- a/pkg/internal/runtime/runtime.go
+++ b/pkg/internal/runtime/runtime.go
@@ -56,6 +56,8 @@ type Args struct {
 	HttpEndpoint string
 	// MetricsPath is the path where metrics will be recorded
 	MetricsPath string
+	// Audience string is used for authentication.
+	Audience string
 }
 
 func (args *Args) Validate() error {
@@ -100,6 +102,7 @@ type Runtime struct {
 	CSIConn        *grpc.ClientConn
 	MetricsManager metrics.CSIMetricsManager
 	DriverName     string
+	Audience       string
 }
 
 // initialize obtains the clients and then the CSI driver name.

--- a/pkg/internal/server/grpc/auth.go
+++ b/pkg/internal/server/grpc/auth.go
@@ -69,6 +69,11 @@ func (s *Server) authenticateRequest(ctx context.Context, securityToken string) 
 }
 
 func (s *Server) getAudienceForDriver(ctx context.Context) (string, error) {
+	if audience := s.audience(); audience != "" {
+		// If the audience string is set, return it.
+		return audience, nil
+	}
+
 	sms, err := s.cbtClient().CbtV1alpha1().SnapshotMetadataServices().Get(ctx, s.driverName(), apimetav1.GetOptions{})
 	if err != nil {
 		klog.FromContext(ctx).Error(err, msgInternalFailedToFindCR, "driver", s.driverName())

--- a/pkg/internal/server/grpc/auth_test.go
+++ b/pkg/internal/server/grpc/auth_test.go
@@ -41,6 +41,14 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 		assert.Error(t, err)
 		assert.Empty(t, retAudience)
 
+		// set audience in Args
+		testAudience := "test-audience"
+		s.config.Runtime.Audience = testAudience
+		retAudience, err = s.getAudienceForDriver(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, testAudience, retAudience)
+		s.config.Runtime.Audience = ""
+
 		// fail via authenticateAndAuthorize
 		err = s.authenticateAndAuthorize(context.Background(), "some-token", "some-namespace")
 		assert.Error(t, err)

--- a/pkg/internal/server/grpc/server.go
+++ b/pkg/internal/server/grpc/server.go
@@ -101,6 +101,10 @@ func (s *Server) csiConnection() *grpc.ClientConn {
 	return s.config.Runtime.CSIConn
 }
 
+func (s *Server) audience() string {
+	return s.config.Runtime.Audience
+}
+
 func buildOptions(config ServerConfig) ([]grpc.ServerOption, error) {
 	tlsOptions, err := buildTLSOption(config.Runtime.TLSCertFile, config.Runtime.TLSKeyFile)
 	if err != nil {

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -55,6 +55,7 @@ const (
 	flagTLSCert                 = "tls-cert"
 	flagTLSKey                  = "tls-key"
 	flagVersion                 = "version"
+	flagAudience                = "audience"
 
 	// tlsCertEnvVar is an environment variable that specifies the path to tls certificate file.
 	tlsCertEnvVar = "TLS_CERT_PATH"
@@ -130,6 +131,7 @@ type sidecarFlagSet struct {
 	showVersion        *bool
 	tlsCert            *string
 	tlsKey             *string
+	audience           *string
 }
 
 var sidecarFlagSetErrorHandling flag.ErrorHandling = flag.ExitOnError // UT interception point.
@@ -149,6 +151,7 @@ func newSidecarFlagSet(name, version string) *sidecarFlagSet {
 	s.grpcPort = s.Int(flagGRPCPort, defaultGRPCPort, "GRPC SnapshotMetadata service port number")
 	s.tlsCert = s.String(flagTLSCert, os.Getenv(tlsCertEnvVar), "Path to the TLS certificate file. Can also be set with the environment variable "+tlsCertEnvVar+".")
 	s.tlsKey = s.String(flagTLSKey, os.Getenv(tlsKeyEnvVar), "Path to the TLS private key file. Can also be set with the environment variable "+tlsKeyEnvVar+".")
+	s.audience = s.String(flagAudience, "", "Audience string used for authentication.")
 
 	s.maxStreamingDurMin = s.Int(flagMaxStreamingDurationMin, defaultMaxStreamingDurationMin, "The maximum duration in minutes for any individual streaming session")
 
@@ -193,6 +196,7 @@ func (s *sidecarFlagSet) runtimeArgsFromFlags() runtime.Args {
 		TLSKeyFile:   *s.tlsKey,
 		HttpEndpoint: *s.httpEndpoint,
 		MetricsPath:  *s.metricsPath,
+		Audience:     *s.audience,
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This commit adds support for passing audience token through cmdline arguements of the sidecar.
This avoids additional API call required to fetch
the SnapshotMetadataService CR to obtain audience
token.
If audience token is not set in cmdline args, the
previous logic of fetching audience token from
SnapshotMetadataService will be used.


**Which issue(s) this PR fixes**:

Fixes #161 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add support for passing audience token through cmdline arguements
```
