### PR TITLE
fix: correct chunk size comment to 1 MiB

### DIFF
--- a/pkg/iterator/emitters.go
+++ b/pkg/iterator/emitters.go
@@ -99,13 +99,13 @@ type VerifierEmitter struct {
 	TargetDevice *os.File
 }
 
-const chunkSize = int64(1024 * 1024) // 4KB
+const chunkSize = int64(1024 * 1024) // 1 MiB
 var (
 	ErrFailedToSeek       = errors.New("failed to seek")
 	ErrContentsDoNotMatch = errors.New("source and target device contents do not match")
 )
 
-// copyBlock will copy chunks of 256 bytes at a time upto to sizeBytes from the source device to the target device.
+// copyBlock will copy chunks of 1 MiB at a time upto to sizeBytes from the source device to the target device.
 func (verifierEmitter *VerifierEmitter) copyBlock(bmd *api.BlockMetadata) error {
 	// Seek to the byteOffset of the source device.
 	_, err := verifierEmitter.SourceDevice.Seek(bmd.ByteOffset, io.SeekStart)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Fix incorrect comments about chunk size.
The actual chunk size is 1 MiB, but comments incorrectly stated 4KB and 256 bytes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
