### PR TITLE
feat: Add multiarch support to csi-snapshot-metadata Dockerfile

### DIFF
--- a/cmd/csi-snapshot-metadata/Dockerfile
+++ b/cmd/csi-snapshot-metadata/Dockerfile
@@ -1,27 +1,6 @@
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
-ARG GRPC_HEALTH_PROBE_VERSION=v0.4.37
-ARG TARGETARCH
-ARG TARGETOS=linux
-ARG LDFLAGS
-ADD https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} /bin/grpc_health_probe
-RUN chmod +x /bin/grpc_health_probe
-
-# Build csi-snapshot-metadata
-WORKDIR /workspace
-COPY go.mod go.sum ./
-COPY cmd/ cmd/
-COPY pkg/ pkg/
-COPY client/ client/
-COPY vendor/ vendor/
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -mod=vendor -a -ldflags "${LDFLAGS}" \
-    -o /bin/csi-snapshot-metadata \
-    ./cmd/csi-snapshot-metadata
-
 FROM gcr.io/distroless/static:latest
 LABEL maintainers="Kubernetes Authors"
 LABEL description="CSI External Snapshot Metadata Sidecar"
-COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
-COPY --from=builder /bin/csi-snapshot-metadata /csi-snapshot-metadata
+ARG binary=./bin/csi-snapshot-metadata
+COPY ${binary} /csi-snapshot-metadata
 ENTRYPOINT ["/csi-snapshot-metadata"]
-

--- a/deploy/example/csi-driver/csi-driver-with-snapshot-metadata-sidecar.yaml
+++ b/deploy/example/csi-driver/csi-driver-with-snapshot-metadata-sidecar.yaml
@@ -34,12 +34,9 @@ spec:
           # fetching the token from SnapshotMetadataService CR.
           # - "--audience=test-backup-client"
           readinessProbe:
-            exec:
-              command:
-              - "/bin/grpc_health_probe"
-              - "-addr=:50051"
-              - "-tls"
-              - "-tls-no-verify"
+            httpGet:
+              path: /health
+              port: 8080
             initialDelaySeconds: 5
           volumeMounts:
             - mountPath: /csi

--- a/pkg/internal/server/grpc/health.go
+++ b/pkg/internal/server/grpc/health.go
@@ -33,8 +33,8 @@ func newHealthServer() *health.Server {
 	return healthServer
 }
 
-// isReady indicates whether the sidecar can serve metadata.
-func (s *Server) isReady() bool {
+// IsReady indicates whether the sidecar can serve metadata.
+func (s *Server) IsReady() bool {
 	resp, err := s.healthServer.Check(context.Background(), &healthpb.HealthCheckRequest{})
 	if err == nil && resp.Status == healthpb.HealthCheckResponse_SERVING {
 		return true
@@ -63,7 +63,7 @@ func (s *Server) shuttingDown() {
 // isCSIDriverReady is a helper for the handlers that returns the appropriate error if the
 // CSI driver is not ready.
 func (s *Server) isCSIDriverReady(ctx context.Context) error {
-	if s.isReady() {
+	if s.IsReady() {
 		return nil
 	}
 

--- a/pkg/internal/server/grpc/health_test.go
+++ b/pkg/internal/server/grpc/health_test.go
@@ -29,22 +29,22 @@ func TestHealthService(t *testing.T) {
 		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
 		server := th.ServerWithRuntime(t, th.Runtime())
 
-		assert.False(t, server.isReady())
+		assert.False(t, server.IsReady())
 
 		server.setReady()
-		assert.True(t, server.isReady())
+		assert.True(t, server.IsReady())
 
 		server.setNotReady()
-		assert.False(t, server.isReady())
+		assert.False(t, server.IsReady())
 
 		server.setReady()
-		assert.True(t, server.isReady())
+		assert.True(t, server.IsReady())
 
 		server.shuttingDown()
-		assert.False(t, server.isReady())
+		assert.False(t, server.IsReady())
 
 		server.setReady()
-		assert.False(t, server.isReady()) // cannot change state once shutdown.
+		assert.False(t, server.IsReady()) // cannot change state once shutdown.
 	})
 
 	t.Run("client-health-checks", func(t *testing.T) {

--- a/pkg/internal/server/grpc/server_test.go
+++ b/pkg/internal/server/grpc/server_test.go
@@ -101,7 +101,7 @@ func TestNewServer(t *testing.T) {
 		assert.NotNil(t, s.grpcServer)
 		assert.Equal(t, s.config.Runtime, &rt)
 		assert.Equal(t, expMaxStreamDur, s.config.MaxStreamDur)
-		assert.False(t, s.isReady()) // initialized to not ready
+		assert.False(t, s.IsReady()) // initialized to not ready
 
 		err = s.Start()
 		assert.NoError(t, err)
@@ -115,7 +115,7 @@ func TestNewServer(t *testing.T) {
 			assert.Contains(t, si, serviceName)
 		}
 
-		assert.False(t, s.isReady()) // not yet ready
+		assert.False(t, s.IsReady()) // not yet ready
 		err = s.isCSIDriverReady(context.Background())
 		assert.Error(t, err)
 		st, ok := status.FromError(err)
@@ -125,11 +125,11 @@ func TestNewServer(t *testing.T) {
 
 		s.CSIDriverIsReady()
 
-		assert.True(t, s.isReady()) // now ready!
+		assert.True(t, s.IsReady()) // now ready!
 		assert.NoError(t, s.isCSIDriverReady(context.Background()))
 
 		s.Stop()
-		assert.False(t, s.isReady())
+		assert.False(t, s.IsReady())
 		assert.Error(t, s.isCSIDriverReady(context.Background()))
 	})
 }

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -112,6 +112,7 @@ func TestSidecarFlagSet(t *testing.T) {
 			GRPCPort:     defaultGRPCPort,
 			TLSCertFile:  expTLSCertFile,
 			TLSKeyFile:   expTLSKeyFile,
+			HttpEndpoint: defaultHTTPEndpoint,
 			MetricsPath:  defaultMetricsPath,
 		}
 


### PR DESCRIPTION
## Summary

This PR replaces the external grpc_health_probe binary with a native HTTP health endpoint, simplifying the container build and removing the need for architecture-specific probe binaries.

## Changes

### 1. Replace grpc_health_probe with HTTP health endpoint
- Remove Docker builder stage that downloaded grpc_health_probe
- Simplify Dockerfile to a single-stage distroless image
- Add native HTTP server at `:8080` with `/health` endpoint
- Health endpoint returns 200 OK when gRPC server is ready, 503 otherwise

### 2. Update deployment configuration
- Change readinessProbe from `exec` (grpc_health_probe) to `httpGet`
- Probe now hits `/health` on port 8080

### 3. New flags and configuration
- HTTP server now enabled by default at `:8080`
- Add `--disable-metrics` flag to optionally disable metrics endpoint
- Health endpoint is always available (not affected by `--disable-metrics`)

## Files Changed

| File | Change |
|------|--------|
| `cmd/csi-snapshot-metadata/Dockerfile` | Remove builder stage, simplify to single-stage |
| `deploy/example/csi-driver/csi-driver-with-snapshot-metadata-sidecar.yaml` | Update readinessProbe to use httpGet |
| `pkg/sidecar/sidecar.go` | Add HTTP health endpoint, new flags |
| `pkg/internal/server/grpc/health.go` | Export `IsReady()` method |
| `pkg/internal/server/grpc/*_test.go` | Update tests for exported method |

## Benefits
- No external binary dependencies for health checks
- Simplified single-stage Dockerfile
- Native multiarch support without downloading arch-specific binaries
- Consistent HTTP-based health checking

---

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Replaces the grpc_health_probe binary with a native HTTP health endpoint, eliminating the need to download architecture-specific probe binaries and simplifying the container image.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
- The HTTP server is now always started on `:8080` by default
- The `/health` endpoint tracks the same readiness state as the previous gRPC health check
- Metrics can be disabled with `--disable-metrics` while keeping the health endpoint

**Does this PR introduce a user-facing change?**:
```release-note
Health checks now use HTTP endpoint (/health on port 8080) instead of grpc_health_probe binary
```