### PR TITLE
Add Renovate automation for container image updates

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,24 @@
+name: Renovate
+
+on:
+  # Run weekly on Mondays at midnight UTC
+  schedule:
+    - cron: "0 0 * * 1"
+  # Allow manual trigger
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: renovatebot/github-action@v46.1.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          configurationFile: renovate.json5
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "dependencyDashboard": false,
+  // Only manage container image updates.
+  // Go modules and GitHub Actions are handled by Dependabot.
+  "enabledManagers": [
+    "custom.regex",
+    "dockerfile"
+  ],
+  "customManagers": [
+    {
+      // Extract container image references from Kubernetes YAML manifests
+      "customType": "regex",
+      "managerFilePatterns": ["deploy/**/*.yaml"],
+      "matchStrings": [
+        "image:\\s*(?<depName>[^:]+):(?<currentValue>[^\\s\"]+)"
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      // Track grpc-health-probe version in Dockerfile ARG
+      "customType": "regex",
+      "managerFilePatterns": ["**/Dockerfile"],
+      "matchStrings": [
+        "ARG GRPC_HEALTH_PROBE_VERSION=(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "grpc-ecosystem/grpc-health-probe",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
+  "packageRules": [
+    {
+      // Skip the staging image that tracks the main branch
+      "matchPackageNames": [
+        "gcr.io/k8s-staging-sig-storage/csi-snapshot-metadata"
+      ],
+      "enabled": false
+    },
+    {
+      // Group all deploy manifest image updates into a single PR
+      "matchManagers": ["custom.regex"],
+      "groupName": "deploy manifest container images",
+      "labels": [
+        "area/dependency",
+        "release-note-none",
+        "ok-to-test"
+      ]
+    },
+    {
+      // Dockerfile base images and tool versions
+      "matchManagers": ["dockerfile"],
+      "groupName": "Dockerfile dependencies",
+      "labels": [
+        "area/dependency",
+        "release-note-none",
+        "ok-to-test"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds self-hosted Renovate via GitHub Actions cron to automate container image version bumps in deploy manifests and Dockerfile (e.g. `hostpathplugin`, `busybox`, `distroless/static`, `grpc-health-probe`)
- Complements existing Dependabot setup which handles Go modules and GitHub Actions
- Runs weekly on Mondays; uses `GITHUB_TOKEN` with repo write permissions (no separate PAT required)
- Groups updates by manager type and applies the same labels as Dependabot (`area/dependency`, `release-note-none`, `ok-to-test`)

Replaces manual PRs like #217.

## Test plan
- [ ] Verify Renovate workflow can be triggered manually via `workflow_dispatch`
- [ ] Confirm Renovate detects container images in `deploy/` YAML files and `Dockerfile`
- [ ] Confirm staging image (`gcr.io/k8s-staging-sig-storage/csi-snapshot-metadata`) is excluded

> [!Note]
> Responses generated with Claude

🤖 Generated with [Claude Code](https://claude.ai/code)