### PR TITLE
Add --tls-min-version, --tls-cipher-suites, --tls-curve-preferences flags

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -6,11 +6,12 @@ on:
 
 jobs:
   minikube-ci:
-    name: Integration test (with${{ matrix.audience == false && 'out' || '' }} audience parameter)
+    name: Integration test (audience=${{ matrix.audience }}, tls_hardened=${{ matrix.tls_hardened }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         audience: [false, true]
+        tls_hardened: [false, true]
     steps:
       - name: Check out the repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -47,6 +48,15 @@ jobs:
           if [ "${{ matrix.audience }}" = "true" ]; then
             echo "Enabling audience parameter in hostpath sidecar patch"
             sed -i '/--tls-key=/a\          - "--audience=test-backup-client"' ~/csi-driver-host-path/deploy/kubernetes-latest/hostpath/csi-snapshot-metadata-sidecar.patch
+          fi
+
+          # Inject TLS hardening flags into the sidecar patch
+          if [ "${{ matrix.tls_hardened }}" = "true" ]; then
+            echo "Injecting TLS hardening flags"
+            PATCH_FILE=~/csi-driver-host-path/deploy/kubernetes-latest/hostpath/csi-snapshot-metadata-sidecar.patch
+            sed -i '/--tls-key=/a\          - "--tls-min-version=VersionTLS13"\n          - "--tls-curve-preferences=X25519,CurveP256"' "$PATCH_FILE"
+            echo "TLS flags injected into sidecar patch:"
+            cat "$PATCH_FILE"
           fi
 
           CSI_SNAPSHOT_METADATA_REGISTRY="gcr.io/k8s-staging-sig-storage" UPDATE_RBAC_RULES="true" CSI_SNAPSHOT_METADATA_TAG="${{ github.sha }}" SNAPSHOT_METADATA_TESTS=true HOSTPATHPLUGIN_REGISTRY="gcr.io/k8s-staging-sig-storage" HOSTPATHPLUGIN_TAG="canary" ~/csi-driver-host-path/deploy/kubernetes-latest/deploy.sh

--- a/pkg/internal/runtime/runtime.go
+++ b/pkg/internal/runtime/runtime.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	cbt "github.com/kubernetes-csi/external-snapshot-metadata/client/clientset/versioned"
+	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/internal/tlsconfig"
 )
 
 type Args struct {
@@ -58,6 +59,12 @@ type Args struct {
 	MetricsPath string
 	// Audience string is used for authentication.
 	Audience string
+	// Minimum TLS version for the gRPC server. Accepted: "VersionTLS12", "VersionTLS13".
+	TLSMinVersion string
+	// Comma-separated list of allowed TLS 1.2 cipher suites (Go names).
+	TLSCipherSuites string
+	// Comma-separated list of preferred elliptic curves for ECDHE (Go names).
+	TLSCurvePreferences string
 }
 
 func (args *Args) Validate() error {
@@ -72,6 +79,18 @@ func (args *Args) Validate() error {
 		return errors.New("missing TLSCertFile")
 	case args.TLSKeyFile == "":
 		return errors.New("missing TLSKeyFile")
+	}
+
+	if _, err := tlsconfig.ParseTLSVersion(args.TLSMinVersion); err != nil {
+		return err
+	}
+
+	if _, err := tlsconfig.ParseCipherSuites(args.TLSCipherSuites); err != nil {
+		return err
+	}
+
+	if _, err := tlsconfig.ParseCurvePreferences(args.TLSCurvePreferences); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/internal/runtime/runtime_test.go
+++ b/pkg/internal/runtime/runtime_test.go
@@ -37,6 +37,9 @@ func TestNew(t *testing.T) {
 			{CSIAddress: "1.2.3.4", CSITimeout: time.Hour},
 			{CSIAddress: "1.2.3.4", CSITimeout: time.Hour, GRPCPort: 10},
 			{CSIAddress: "1.2.3.4", CSITimeout: time.Hour, GRPCPort: 10, TLSCertFile: "/certFile"},
+			{CSIAddress: "1.2.3.4", CSITimeout: time.Hour, GRPCPort: 10, TLSCertFile: "/c", TLSKeyFile: "/k", TLSMinVersion: "TLS10"},
+			{CSIAddress: "1.2.3.4", CSITimeout: time.Hour, GRPCPort: 10, TLSCertFile: "/c", TLSKeyFile: "/k", TLSCipherSuites: "INVALID"},
+			{CSIAddress: "1.2.3.4", CSITimeout: time.Hour, GRPCPort: 10, TLSCertFile: "/c", TLSKeyFile: "/k", TLSCurvePreferences: "INVALID"},
 		}
 		for i, tc := range invalidArgs {
 			t.Run(fmt.Sprintf("invalid-%d", i), func(t *testing.T) {

--- a/pkg/internal/server/grpc/server.go
+++ b/pkg/internal/server/grpc/server.go
@@ -38,6 +38,7 @@ import (
 	cbt "github.com/kubernetes-csi/external-snapshot-metadata/client/clientset/versioned"
 	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/api"
 	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/internal/runtime"
+	"github.com/kubernetes-csi/external-snapshot-metadata/pkg/internal/tlsconfig"
 )
 
 const (
@@ -66,6 +67,7 @@ type Server struct {
 	grpcServer   *grpc.Server
 	healthServer *health.Server
 	opNumber     int64
+	tlsCfg       *tls.Config
 }
 
 func NewServer(config ServerConfig) (*Server, error) {
@@ -77,19 +79,44 @@ func NewServer(config ServerConfig) (*Server, error) {
 		return nil, errors.New("the certificate watcher/provider for the gRPC server is unset.")
 	}
 
+	minVersion, err := tlsconfig.ParseTLSVersion(config.Runtime.TLSMinVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	cipherSuites, err := tlsconfig.ParseCipherSuites(config.Runtime.TLSCipherSuites)
+	if err != nil {
+		return nil, err
+	}
+
+	curvePrefs, err := tlsconfig.ParseCurvePreferences(config.Runtime.TLSCurvePreferences)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsCfg := &tls.Config{
+		GetCertificate:   config.Certwatcher.GetCertificate,
+		ClientAuth:       tls.NoClientCert,
+		MinVersion:       minVersion,
+		CipherSuites:     cipherSuites,
+		CurvePreferences: curvePrefs,
+	}
+
+	if tlsCfg.MinVersion >= tls.VersionTLS13 && len(tlsCfg.CipherSuites) > 0 {
+		klog.Warning("TLS 1.3+ ignores the configured cipher suites; cipher suite setting has no effect")
+	}
+
+	if config.Runtime.TLSMinVersion != "" || config.Runtime.TLSCipherSuites != "" || config.Runtime.TLSCurvePreferences != "" {
+		klog.Infof("TLS configuration: min-version=%q, cipher-suites=%q, curve-preferences=%q", config.Runtime.TLSMinVersion, config.Runtime.TLSCipherSuites, config.Runtime.TLSCurvePreferences)
+	}
+
 	return &Server{
 		config: config,
 		grpcServer: grpc.NewServer(
-			grpc.Creds(
-				credentials.NewTLS(
-					&tls.Config{
-						GetCertificate: config.Certwatcher.GetCertificate,
-						ClientAuth:     tls.NoClientCert,
-					},
-				),
-			),
+			grpc.Creds(credentials.NewTLS(tlsCfg)),
 		),
 		healthServer: newHealthServer(),
+		tlsCfg:       tlsCfg,
 	}, nil
 }
 

--- a/pkg/internal/server/grpc/server_test.go
+++ b/pkg/internal/server/grpc/server_test.go
@@ -18,6 +18,7 @@ package grpc
 
 import (
 	"context"
+	"crypto/tls"
 	"sync"
 	"testing"
 	"time"
@@ -147,6 +148,158 @@ func TestNewServer(t *testing.T) {
 		s.Stop()
 		assert.False(t, s.IsReady())
 		assert.Error(t, s.isCSIDriverReady(context.Background()))
+	})
+}
+
+func TestNewServerTLSConfig(t *testing.T) {
+	t.Run("tls12-with-ciphers-and-curves", func(t *testing.T) {
+		rth := runtime.NewTestHarness().WithTestTLSFiles(t)
+		defer rth.RemoveTestTLSFiles(t)
+		rta := rth.RuntimeArgs()
+
+		rt := &runtime.Runtime{
+			Args: runtime.Args{
+				GRPCPort:            rta.GRPCPort,
+				TLSCertFile:         rta.TLSCertFile,
+				TLSKeyFile:          rta.TLSKeyFile,
+				TLSMinVersion:       "VersionTLS12",
+				TLSCipherSuites:     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				TLSCurvePreferences: "X25519,CurveP256",
+			},
+			DriverName: "driver",
+			CBTClient:  fakecbt.NewSimpleClientset(),
+			KubeClient: fake.NewSimpleClientset(),
+		}
+
+		cw, err := cw.NewCertWatcher(rt.TLSCertFile, rt.TLSKeyFile)
+		assert.NoError(t, err)
+
+		s, err := NewServer(ServerConfig{
+			Runtime:     rt,
+			Certwatcher: cw,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+
+		tc := s.tlsCfg
+		assert.NotNil(t, tc)
+		assert.Equal(t, uint16(tls.VersionTLS12), tc.MinVersion)
+		assert.Len(t, tc.CipherSuites, 1)
+		assert.Len(t, tc.CurvePreferences, 2)
+	})
+
+	t.Run("tls13-without-ciphers", func(t *testing.T) {
+		rth := runtime.NewTestHarness().WithTestTLSFiles(t)
+		defer rth.RemoveTestTLSFiles(t)
+		rta := rth.RuntimeArgs()
+
+		rt := &runtime.Runtime{
+			Args: runtime.Args{
+				GRPCPort:            rta.GRPCPort,
+				TLSCertFile:         rta.TLSCertFile,
+				TLSKeyFile:          rta.TLSKeyFile,
+				TLSMinVersion:       "VersionTLS13",
+				TLSCurvePreferences: "X25519",
+			},
+			DriverName: "driver",
+			CBTClient:  fakecbt.NewSimpleClientset(),
+			KubeClient: fake.NewSimpleClientset(),
+		}
+
+		cw, err := cw.NewCertWatcher(rt.TLSCertFile, rt.TLSKeyFile)
+		assert.NoError(t, err)
+
+		s, err := NewServer(ServerConfig{
+			Runtime:     rt,
+			Certwatcher: cw,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+
+		tc := s.tlsCfg
+		assert.NotNil(t, tc)
+		assert.Equal(t, uint16(tls.VersionTLS13), tc.MinVersion)
+		assert.Nil(t, tc.CipherSuites)
+		assert.Len(t, tc.CurvePreferences, 1)
+		assert.Equal(t, tls.X25519, tc.CurvePreferences[0])
+	})
+
+	t.Run("invalid-cipher-suite", func(t *testing.T) {
+		rth := runtime.NewTestHarness().WithTestTLSFiles(t)
+		defer rth.RemoveTestTLSFiles(t)
+		rta := rth.RuntimeArgs()
+
+		rt := &runtime.Runtime{
+			Args: runtime.Args{
+				GRPCPort:        rta.GRPCPort,
+				TLSCertFile:     rta.TLSCertFile,
+				TLSKeyFile:      rta.TLSKeyFile,
+				TLSCipherSuites: "INVALID_CIPHER",
+			},
+		}
+
+		cw, err := cw.NewCertWatcher(rt.TLSCertFile, rt.TLSKeyFile)
+		assert.NoError(t, err)
+
+		s, err := NewServer(ServerConfig{
+			Runtime:     rt,
+			Certwatcher: cw,
+		})
+		assert.Error(t, err)
+		assert.Nil(t, s)
+		assert.Contains(t, err.Error(), "unsupported or insecure cipher suite")
+	})
+
+	t.Run("invalid-curve", func(t *testing.T) {
+		rth := runtime.NewTestHarness().WithTestTLSFiles(t)
+		defer rth.RemoveTestTLSFiles(t)
+		rta := rth.RuntimeArgs()
+
+		rt := &runtime.Runtime{
+			Args: runtime.Args{
+				GRPCPort:            rta.GRPCPort,
+				TLSCertFile:         rta.TLSCertFile,
+				TLSKeyFile:          rta.TLSKeyFile,
+				TLSCurvePreferences: "InvalidCurve",
+			},
+		}
+
+		cw, err := cw.NewCertWatcher(rt.TLSCertFile, rt.TLSKeyFile)
+		assert.NoError(t, err)
+
+		s, err := NewServer(ServerConfig{
+			Runtime:     rt,
+			Certwatcher: cw,
+		})
+		assert.Error(t, err)
+		assert.Nil(t, s)
+		assert.Contains(t, err.Error(), "unsupported curve")
+	})
+
+	t.Run("invalid-tls-version", func(t *testing.T) {
+		rth := runtime.NewTestHarness().WithTestTLSFiles(t)
+		defer rth.RemoveTestTLSFiles(t)
+		rta := rth.RuntimeArgs()
+
+		rt := &runtime.Runtime{
+			Args: runtime.Args{
+				GRPCPort:      rta.GRPCPort,
+				TLSCertFile:   rta.TLSCertFile,
+				TLSKeyFile:    rta.TLSKeyFile,
+				TLSMinVersion: "TLS12",
+			},
+		}
+
+		cw, err := cw.NewCertWatcher(rt.TLSCertFile, rt.TLSKeyFile)
+		assert.NoError(t, err)
+
+		s, err := NewServer(ServerConfig{
+			Runtime:     rt,
+			Certwatcher: cw,
+		})
+		assert.Error(t, err)
+		assert.Nil(t, s)
+		assert.Contains(t, err.Error(), "unsupported TLS version")
 	})
 }
 

--- a/pkg/internal/tlsconfig/tlsconfig.go
+++ b/pkg/internal/tlsconfig/tlsconfig.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tlsconfig
+
+import (
+	"crypto/tls"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var tlsVersions = map[string]uint16{
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+var tlsCurves = map[string]tls.CurveID{
+	"X25519":         tls.X25519,
+	"CurveP256":      tls.CurveP256,
+	"CurveP384":      tls.CurveP384,
+	"CurveP521":      tls.CurveP521,
+	"X25519MLKEM768": tls.X25519MLKEM768,
+}
+
+// ParseTLSVersion converts a TLS version string to its uint16 constant.
+// Returns 0 for empty input (Go default). Accepts "VersionTLS12", "VersionTLS13".
+func ParseTLSVersion(s string) (uint16, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	v, ok := tlsVersions[s]
+	if !ok {
+		return 0, fmt.Errorf("unsupported TLS version %q, must be one of: VersionTLS12, VersionTLS13", s)
+	}
+
+	return v, nil
+}
+
+// ParseCipherSuites converts a comma-separated list of Go cipher suite names to their uint16 IDs.
+// Returns nil for empty input (Go defaults). Only accepts safe suites from tls.CipherSuites().
+func ParseCipherSuites(csv string) ([]uint16, error) {
+	if csv == "" {
+		return nil, nil
+	}
+
+	cipherSuiteMap := make(map[string]uint16, len(tls.CipherSuites()))
+	for _, cs := range tls.CipherSuites() {
+		cipherSuiteMap[cs.Name] = cs.ID
+	}
+
+	names := strings.Split(csv, ",")
+	suites := make([]uint16, 0, len(names))
+
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+
+		id, ok := cipherSuiteMap[name]
+		if !ok {
+			return nil, fmt.Errorf("unsupported or insecure cipher suite: %q", name)
+		}
+
+		suites = append(suites, id)
+	}
+
+	if len(suites) == 0 {
+		return nil, nil
+	}
+
+	return suites, nil
+}
+
+// ParseCurvePreferences converts a comma-separated list of curve names to tls.CurveID values.
+// Returns nil for empty input (Go defaults).
+// Supported: X25519, CurveP256, CurveP384, CurveP521, X25519MLKEM768.
+func ParseCurvePreferences(csv string) ([]tls.CurveID, error) {
+	if csv == "" {
+		return nil, nil
+	}
+
+	names := strings.Split(csv, ",")
+	curves := make([]tls.CurveID, 0, len(names))
+
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+
+		id, ok := tlsCurves[name]
+		if !ok {
+			return nil, fmt.Errorf("unsupported curve %q, must be one of: %s", name, supportedCurveNames())
+		}
+
+		curves = append(curves, id)
+	}
+
+	if len(curves) == 0 {
+		return nil, nil
+	}
+
+	return curves, nil
+}
+
+func supportedCurveNames() string {
+	names := make([]string, 0, len(tlsCurves))
+	for k := range tlsCurves {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}

--- a/pkg/internal/tlsconfig/tlsconfig_test.go
+++ b/pkg/internal/tlsconfig/tlsconfig_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tlsconfig
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTLSVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    uint16
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: 0},
+		{name: "tls12", input: "VersionTLS12", want: tls.VersionTLS12},
+		{name: "tls13", input: "VersionTLS13", want: tls.VersionTLS13},
+		{name: "invalid", input: "TLS12", wantErr: true},
+		{name: "tls10-rejected", input: "VersionTLS10", wantErr: true},
+		{name: "tls11-rejected", input: "VersionTLS11", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseTLSVersion(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestParseCipherSuites(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantLen int
+		wantErr bool
+	}{
+		{name: "empty", input: "", wantLen: 0},
+		{name: "single", input: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", wantLen: 1},
+		{name: "multiple", input: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", wantLen: 2},
+		{name: "with-spaces", input: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 , TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", wantLen: 2},
+		{name: "trailing-comma", input: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,", wantLen: 1},
+		{name: "comma-only", input: ",", wantLen: 0},
+		{name: "spaces-and-commas", input: ", ,", wantLen: 0},
+		{name: "invalid", input: "FAKE_CIPHER", wantErr: true},
+		{name: "insecure-rejected", input: "TLS_RSA_WITH_RC4_128_SHA", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseCipherSuites(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Len(t, got, tc.wantLen)
+			}
+		})
+	}
+}
+
+func TestParseCurvePreferences(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []tls.CurveID
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: nil},
+		{name: "x25519", input: "X25519", want: []tls.CurveID{tls.X25519}},
+		{name: "multiple", input: "X25519,CurveP256,CurveP384", want: []tls.CurveID{tls.X25519, tls.CurveP256, tls.CurveP384}},
+		{name: "p521", input: "CurveP521", want: []tls.CurveID{tls.CurveP521}},
+		{name: "mlkem768", input: "X25519MLKEM768", want: []tls.CurveID{tls.X25519MLKEM768}},
+		{name: "with-spaces", input: "X25519 , CurveP256", want: []tls.CurveID{tls.X25519, tls.CurveP256}},
+		{name: "comma-only", input: ",", want: nil},
+		{name: "invalid", input: "InvalidCurve", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseCurvePreferences(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestSupportedCurves(t *testing.T) {
+	expected := []string{"X25519", "CurveP256", "CurveP384", "CurveP521", "X25519MLKEM768"}
+	for _, name := range expected {
+		_, ok := tlsCurves[name]
+		assert.True(t, ok, "expected curve %q in tlsCurves map", name)
+	}
+	assert.Equal(t, len(expected), len(tlsCurves))
+}

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -57,6 +57,9 @@ const (
 	flagMetricsPath             = "metrics-path"
 	flagTLSCert                 = "tls-cert"
 	flagTLSKey                  = "tls-key"
+	flagTLSMinVersion           = "tls-min-version"
+	flagTLSCipherSuites         = "tls-cipher-suites"
+	flagTLSCurvePreferences     = "tls-curve-preferences"
 	flagVersion                 = "version"
 	flagAudience                = "audience"
 	flagDisableMetrics          = "disable-metrics"
@@ -153,20 +156,23 @@ type sidecarFlagSet struct {
 	version string
 
 	// flag variables
-	csiAddress         *string
-	csiTimeout         *time.Duration
-	grpcPort           *int
-	httpEndpoint       *string
-	kubeAPIBurst       *int
-	kubeAPIQPS         *float64
-	kubeconfig         *string
-	maxStreamingDurMin *int
-	metricsPath        *string
-	showVersion        *bool
-	tlsCert            *string
-	tlsKey             *string
-	audience           *string
-	disableMetrics     *bool
+	csiAddress          *string
+	csiTimeout          *time.Duration
+	grpcPort            *int
+	httpEndpoint        *string
+	kubeAPIBurst        *int
+	kubeAPIQPS          *float64
+	kubeconfig          *string
+	maxStreamingDurMin  *int
+	metricsPath         *string
+	showVersion         *bool
+	tlsCert             *string
+	tlsKey              *string
+	tlsMinVersion       *string
+	tlsCipherSuites     *string
+	tlsCurvePreferences *string
+	audience            *string
+	disableMetrics      *bool
 }
 
 var sidecarFlagSetErrorHandling flag.ErrorHandling = flag.ExitOnError // UT interception point.
@@ -186,6 +192,9 @@ func newSidecarFlagSet(name, version string) *sidecarFlagSet {
 	s.grpcPort = s.Int(flagGRPCPort, defaultGRPCPort, "GRPC SnapshotMetadata service port number")
 	s.tlsCert = s.String(flagTLSCert, os.Getenv(tlsCertEnvVar), "Path to the TLS certificate file. Can also be set with the environment variable "+tlsCertEnvVar+".")
 	s.tlsKey = s.String(flagTLSKey, os.Getenv(tlsKeyEnvVar), "Path to the TLS private key file. Can also be set with the environment variable "+tlsKeyEnvVar+".")
+	s.tlsMinVersion = s.String(flagTLSMinVersion, "", "Minimum TLS version. Accepted values: VersionTLS12, VersionTLS13. Empty uses Go default (TLS 1.2).")
+	s.tlsCipherSuites = s.String(flagTLSCipherSuites, "", "Comma-separated list of allowed TLS 1.2 cipher suites (Go names). Empty uses Go defaults. Ignored when a TLS 1.3 connection is negotiated.")
+	s.tlsCurvePreferences = s.String(flagTLSCurvePreferences, "", "Comma-separated list of preferred elliptic curves for ECDHE (e.g. X25519,CurveP256). Empty uses Go defaults.")
 	s.audience = s.String(flagAudience, "", "Audience string used for authentication.")
 
 	s.maxStreamingDurMin = s.Int(flagMaxStreamingDurationMin, defaultMaxStreamingDurationMin, "The maximum duration in minutes for any individual streaming session")
@@ -227,17 +236,20 @@ func (s *sidecarFlagSet) parseFlagsAndHandleShowVersion(args []string) (handledS
 
 func (s *sidecarFlagSet) runtimeArgsFromFlags() runtime.Args {
 	return runtime.Args{
-		CSIAddress:   *s.csiAddress,
-		CSITimeout:   *s.csiTimeout,
-		KubeAPIBurst: *s.kubeAPIBurst,
-		KubeAPIQPS:   (float32)(*s.kubeAPIQPS),
-		Kubeconfig:   *s.kubeconfig,
-		GRPCPort:     *s.grpcPort,
-		TLSCertFile:  *s.tlsCert,
-		TLSKeyFile:   *s.tlsKey,
-		HttpEndpoint: *s.httpEndpoint,
-		MetricsPath:  *s.metricsPath,
-		Audience:     *s.audience,
+		CSIAddress:          *s.csiAddress,
+		CSITimeout:          *s.csiTimeout,
+		KubeAPIBurst:        *s.kubeAPIBurst,
+		KubeAPIQPS:          (float32)(*s.kubeAPIQPS),
+		Kubeconfig:          *s.kubeconfig,
+		GRPCPort:            *s.grpcPort,
+		TLSCertFile:         *s.tlsCert,
+		TLSKeyFile:          *s.tlsKey,
+		HttpEndpoint:        *s.httpEndpoint,
+		MetricsPath:         *s.metricsPath,
+		Audience:            *s.audience,
+		TLSMinVersion:       *s.tlsMinVersion,
+		TLSCipherSuites:     *s.tlsCipherSuites,
+		TLSCurvePreferences: *s.tlsCurvePreferences,
 	}
 }
 
@@ -284,6 +296,18 @@ func (s *sidecarFlagSet) runtimeArgsToArgv(progName string, rta runtime.Args) []
 
 	if rta.MetricsPath != defaultMetricsPath {
 		argv = append(argv, "-"+flagMetricsPath, rta.MetricsPath)
+	}
+
+	if rta.TLSMinVersion != "" {
+		argv = append(argv, "-"+flagTLSMinVersion, rta.TLSMinVersion)
+	}
+
+	if rta.TLSCipherSuites != "" {
+		argv = append(argv, "-"+flagTLSCipherSuites, rta.TLSCipherSuites)
+	}
+
+	if rta.TLSCurvePreferences != "" {
+		argv = append(argv, "-"+flagTLSCurvePreferences, rta.TLSCurvePreferences)
 	}
 
 	return argv

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -298,6 +298,10 @@ func (s *sidecarFlagSet) runtimeArgsToArgv(progName string, rta runtime.Args) []
 		argv = append(argv, "-"+flagMetricsPath, rta.MetricsPath)
 	}
 
+	if rta.Audience != "" {
+		argv = append(argv, "-"+flagAudience, rta.Audience)
+	}
+
 	if rta.TLSMinVersion != "" {
 		argv = append(argv, "-"+flagTLSMinVersion, rta.TLSMinVersion)
 	}


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

The gRPC server previously hardcoded its TLS configuration with no way for operators to control the minimum TLS version, allowed cipher suites, or preferred elliptic curves. This made it difficult to meet specific security compliance requirements or harden deployments beyond Go defaults.

This PR adds three new CLI flags to the sidecar:

| Flag | Description | Default |
|---|---|---|
| `--tls-min-version` | Minimum TLS version (`VersionTLS12`, `VersionTLS13`) | Go default (TLS 1.2) |
| `--tls-cipher-suites` | Comma-separated list of allowed TLS 1.2 cipher suites (Go names) | Go defaults |
| `--tls-curve-preferences` | Comma-separated list of preferred elliptic curves (`X25519`, `CurveP256`, `CurveP384`, `CurveP521`, `X25519MLKEM768`) | Go defaults |

Key behaviors:
- Empty values use Go defaults (no change from current behavior)
- Only safe cipher suites from `tls.CipherSuites()` are accepted; insecure suites are rejected with a clear error
- A warning is logged when `--tls-min-version=VersionTLS13` is set with `--tls-cipher-suites`, since Go ignores cipher suite configuration for TLS 1.3 connections
- TLS 1.0 and 1.1 are deliberately rejected as a security policy
- All TLS flags are logged at startup when any is set

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

- Parsing utilities live in a new `pkg/internal/tlsconfig` package using stdlib `crypto/tls` APIs — no new dependencies
- TLS fields are validated early in `Args.Validate()` and parsed again in `NewServer` to construct `tls.Config`
- Curve name map is hardcoded (Go has no dynamic `tls.Curves()` API unlike `tls.CipherSuites()`)
- `k8s.io/component-base/cli/flag` was considered but not used: its curve API takes `[]int32` (not string names), it accepts insecure cipher suites by default, and it's not vendored

This change is consistent with existing patterns:

- apiserver — mirrors the flag shape already used by [kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) via [k8s.io/apiserver's SecureServingOptions](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/serving.go) (--tls-cipher-suites, --tls-min-version, --tls-curve-preferences, the latter added upstream in [kubernetes/kubernetes#137115](https://github.com/kubernetes/kubernetes/pull/137115)).
- kubelet CLI + TLS 1.3 check — same flags on the [kubelet CLI](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/), and the TLS 1.3 + cipher-suites warning here follows [cmd/kubelet/app/server.go#L1228-L1232](https://github.com/kubernetes/kubernetes/blob/4f711496824163f8d6b2ceecdb58b418538fbf69/cmd/kubelet/app/server.go#L1228-L1232), which logs the same "TLS 1.3 cipher suites are not configurable, ignoring --tls-cipher-suites" warning.

**Does this PR introduce a user-facing change?**:

```release-note
Add --tls-min-version, --tls-cipher-suites, and --tls-curve-preferences flags to configure TLS parameters for the gRPC server.
```