### PR TITLE
Remove Runtime.Audience field that shadows Args.Audience

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -33,13 +33,6 @@ jobs:
         run: |
           ./scripts/deploy-snapshot-controller.sh deploy
 
-      - name: Configure audience parameter
-        run: |
-          if [ "${{ matrix.audience }}" = "true" ]; then
-            echo "Enabling audience parameter"
-            sed -i 's/# - "--audience=test-backup-client"/- "--audience=test-backup-client"/' deploy/example/csi-driver/csi-driver-with-snapshot-metadata-sidecar.yaml
-          fi
-
       - name: Deploy csi-hostpath-driver
         run: |
           kubectl apply -f ./client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml
@@ -49,6 +42,12 @@ jobs:
           # Patch deploy-hostpath.sh to allow CSI_SNAPSHOT_METADATA_TAG to override the manifest URLs
           # (upstream hardcodes `false` for csi-snapshot-metadata, preventing env var override)
           sed -i 's/rbac_version "\${BASE_DIR}\/hostpath\/csi-snapshot-metadata-sidecar.patch" csi-snapshot-metadata false/rbac_version "${BASE_DIR}\/hostpath\/csi-snapshot-metadata-sidecar.patch" csi-snapshot-metadata true/g' ~/csi-driver-host-path/deploy/util/deploy-hostpath.sh
+
+          # Inject --audience flag into the hostpath sidecar patch
+          if [ "${{ matrix.audience }}" = "true" ]; then
+            echo "Enabling audience parameter in hostpath sidecar patch"
+            sed -i '/--tls-key=/a\          - "--audience=test-backup-client"' ~/csi-driver-host-path/deploy/kubernetes-latest/hostpath/csi-snapshot-metadata-sidecar.patch
+          fi
 
           CSI_SNAPSHOT_METADATA_REGISTRY="gcr.io/k8s-staging-sig-storage" UPDATE_RBAC_RULES="true" CSI_SNAPSHOT_METADATA_TAG="${{ github.sha }}" SNAPSHOT_METADATA_TESTS=true HOSTPATHPLUGIN_REGISTRY="gcr.io/k8s-staging-sig-storage" HOSTPATHPLUGIN_TAG="canary" ~/csi-driver-host-path/deploy/kubernetes-latest/deploy.sh
 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -197,6 +197,21 @@ jobs:
             echo "Command failed as expected"
           fi
 
+      - name: Verify --audience flag takes priority over SMS CR
+        if: ${{ matrix.audience == true }}
+        run: |
+          echo "Patch SMS CR with wrong audience to verify sidecar ignores it"
+          kubectl patch snapshotmetadataservice hostpath.csi.k8s.io --type='merge' -p '{"spec":{"audience":"wrong-audience"}}'
+
+          echo "Run lister — should fail (token created with wrong audience, sidecar expects cmdline audience)"
+          export failed=0
+          kubectl exec backup-app-client -- /snapshot-metadata-lister -max-results 10 -snapshot snap-1 -starting-offset 0 -namespace default -kubeconfig="" 2>&1 || { export failed=1; true; }
+          if [ $failed -ne 1 ]; then
+            echo "ERROR: lister succeeded despite wrong SMS CR audience — sidecar is reading SMS CR instead of --audience flag"
+            exit 1
+          fi
+          echo "Correctly failed: sidecar used --audience flag, rejected token with wrong SMS CR audience"
+
       - name: Log the status of the failed driver pod
         if: ${{ failure() }}
         run: |

--- a/pkg/internal/runtime/runtime.go
+++ b/pkg/internal/runtime/runtime.go
@@ -102,7 +102,6 @@ type Runtime struct {
 	CSIConn        *grpc.ClientConn
 	MetricsManager metrics.CSIMetricsManager
 	DriverName     string
-	Audience       string
 }
 
 // initialize obtains the clients and then the CSI driver name.

--- a/pkg/internal/runtime/runtime_test.go
+++ b/pkg/internal/runtime/runtime_test.go
@@ -148,6 +148,15 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestRuntimeAudienceResolvesToArgs(t *testing.T) {
+	rt := &Runtime{
+		Args: Args{
+			Audience: "test-audience",
+		},
+	}
+	assert.Equal(t, "test-audience", rt.Audience)
+}
+
 func TestWaitTillCSIDriverIsValidated(t *testing.T) {
 	t.Run("probe-error", func(t *testing.T) {
 		th := NewTestHarness().WithMockCSIDriver(t)

--- a/pkg/internal/server/grpc/auth_test.go
+++ b/pkg/internal/server/grpc/auth_test.go
@@ -29,6 +29,54 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 )
 
+func TestGetAudienceForDriver(t *testing.T) {
+	t.Run("args-audience-takes-priority-over-cr", func(t *testing.T) {
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		rt := th.Runtime()
+		rt.Args.Audience = "cmdline-audience"
+		s := th.ServerWithRuntime(t, rt)
+
+		retAudience, err := s.getAudienceForDriver(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, "cmdline-audience", retAudience)
+		assert.NotEqual(t, th.Audience, retAudience, "should use Args audience, not SMS CR audience")
+	})
+
+	t.Run("falls-back-to-cr-when-args-empty", func(t *testing.T) {
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		rt := th.Runtime()
+		assert.Empty(t, rt.Args.Audience)
+		s := th.ServerWithRuntime(t, rt)
+
+		retAudience, err := s.getAudienceForDriver(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, th.Audience, retAudience)
+	})
+
+	t.Run("cr-lookup-fails", func(t *testing.T) {
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		rt := th.Runtime()
+		rt.DriverName += "nonexistent"
+		s := th.ServerWithRuntime(t, rt)
+
+		retAudience, err := s.getAudienceForDriver(context.Background())
+		assert.Error(t, err)
+		assert.Empty(t, retAudience)
+	})
+
+	t.Run("args-audience-skips-cr-even-if-cr-would-fail", func(t *testing.T) {
+		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
+		rt := th.Runtime()
+		rt.Args.Audience = "cmdline-audience"
+		rt.DriverName += "nonexistent"
+		s := th.ServerWithRuntime(t, rt)
+
+		retAudience, err := s.getAudienceForDriver(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, "cmdline-audience", retAudience)
+	})
+}
+
 func TestAuthenticateAndAuthorize(t *testing.T) {
 	t.Run("crd-get-error", func(t *testing.T) {
 		th := newTestHarness().WithFakeClientAPIs().WithMockCSIDriver(t)
@@ -43,11 +91,11 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 
 		// set audience in Args
 		testAudience := "test-audience"
-		s.config.Runtime.Audience = testAudience
+		s.config.Runtime.Args.Audience = testAudience
 		retAudience, err = s.getAudienceForDriver(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, testAudience, retAudience)
-		s.config.Runtime.Audience = ""
+		s.config.Runtime.Args.Audience = ""
 
 		// fail via authenticateAndAuthorize
 		err = s.authenticateAndAuthorize(context.Background(), "some-token", "some-namespace")


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`Runtime` embeds `Args` which has an `Audience` field set from the `--audience` flag. `Runtime` also declared its own `Audience` field, which Go resolves first — shadowing the embedded `Args.Audience`. This made `--audience` a no-op: the flag was parsed but never read.

The sidecar fell back to SMS CR lookup for the audience, which happened to return the same value in integration tests — so the bug was never caught.

This PR:
- Removes the redundant `Runtime.Audience` field so `s.config.Runtime.Audience` resolves to the embedded `Args.Audience` set from the flag
- Fixes the `audience: true` integration test to inject the `--audience` flag into the correct file (`csi-snapshot-metadata-sidecar.patch` after `csi-driver-host-path` clone, not the example yaml before clone)
- Adds a negative test: patches SMS CR with a wrong audience after tests pass — lister must fail, proving the sidecar reads the `--audience` flag, not the SMS CR

**Which issue(s) this PR fixes**:

Fixes #263

**Special notes for your reviewer**:

- The old `Configure audience parameter` step sed'd `deploy/example/csi-driver/csi-driver-with-snapshot-metadata-sidecar.yaml` — but the hostpath deploy script reads from `~/csi-driver-host-path/deploy/kubernetes-latest/hostpath/csi-snapshot-metadata-sidecar.patch`. The sed ran on a file the deploy never reads
- Unit tests in `auth_test.go` cover: args audience takes priority over CR, CR fallback, CR failure, args audience skips CR even when CR would fail
- `runtime_test.go` adds a compile-time regression test: if someone re-adds `Runtime.Audience`, Go's resolution changes and the test fails

**Does this PR introduce a user-facing change?**:

```release-note
Fix --audience flag being silently ignored due to Go struct field shadowing. The sidecar now correctly reads the audience from the command-line flag.
```